### PR TITLE
Address two #562 bugs; integrate "prettier" autoformatter for JS and CSS code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
   # headless-chrome and qunit.
   # node-qunit-puppeteer installs its own chromium as a dependency.
   # hence, a separate chrome installation is not required.
-  - npm install -g node-qunit-puppeteer
+  # ...also, install "prettier" for JS/CSS/HTML auto formatting.
+  - npm install -g node-qunit-puppeteer prettier
 install:
   # Hard limit for transaction log, to prevent VHD from filling during tests
   - psql -c "ALTER SYSTEM SET max_wal_size=2"
@@ -95,6 +96,7 @@ script:
   - python labcontrol/gui/js_tests/js_tester.py all-tests
   - nosetests --exclude-dir=labcontrol/gui/js_tests --with-doctest --with-coverage -v --cover-package=labcontrol
   - flake8 labman setup.py scripts/*
+  - make festylecheck
   - labcontrol/db/tests/tester.py integration_tests
   - labcontrol/db/tests/tester.py stress_tests --num_plates_amplicon 2 --num_plates_shotgun 2
   - labcontrol start-webserver &

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   # headless-chrome and qunit.
   # node-qunit-puppeteer installs its own chromium as a dependency.
   # hence, a separate chrome installation is not required.
-  # ...also, install "prettier" for JS/CSS/HTML auto formatting.
+  # ...also, install "prettier" for front-end code auto formatting.
   - npm install -g node-qunit-puppeteer prettier
 install:
   # Hard limit for transaction log, to prevent VHD from filling during tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# NOTE 1: these targets require the "prettier" Node.js package is globally
+# installed
+#
+# NOTE 2: this code was derived from Qurro's Makefile
+# (https://github.com/biocore/qurro/blob/master/Makefile)
+#
+# NOTE 3: HTML code is currently not included in these operations, since it
+# seems to break prettier. (I think some of that is due to actual HTML errors,
+# but some of that seems to be due to the Tornado template syntax messing
+# things up.)
+.PHONY: festyle festylecheck
+
+JS_CSS_CODE_LOCS = labcontrol/gui/static/js/*.js labcontrol/gui/static/css/labcontrol.css labcontrol/gui/js_tests/*.js
+HTML_CODE_LOCS = labcontrol/gui/templates/*.html labcontrol/gui/js_tests/*.html
+
+# This target auto-formats all of the JS and CSS code to be compliant with
+# prettier.
+festyle:
+	@# To be extra safe, do a dry run of prettier and check that it hasn't
+	@# changed the code's abstract syntax tree.
+	prettier --debug-check $(JS_CSS_CODE_LOCS)
+	prettier --write $(JS_CSS_CODE_LOCS)
+
+# This target checks to make sure all of the JS and CSS code *is* compliant
+# with prettier. Will be run on Travis.
+festylecheck:
+	prettier --check $(JS_CSS_CODE_LOCS)

--- a/labcontrol/gui/js_tests/addPlateModal_tests.js
+++ b/labcontrol/gui/js_tests/addPlateModal_tests.js
@@ -5,150 +5,162 @@
 // addPlateModal.js
 
 // Tests of function insertPlateModalDiv
-QUnit.module("insertPlateModalDiv", function (hooks) {
-    // Verify correct behavior using default arguments
-    QUnit.test("default arguments", function (assert) {
-        //jquery selector strings
-        let modalIdDivSelectorStr = "body div#addPlateModal";
-        let tableIdSelectorStr = "body table#searchPlateTable";
+QUnit.module("insertPlateModalDiv", function(hooks) {
+  // Verify correct behavior using default arguments
+  QUnit.test("default arguments", function(assert) {
+    //jquery selector strings
+    let modalIdDivSelectorStr = "body div#addPlateModal";
+    let tableIdSelectorStr = "body table#searchPlateTable";
 
-        // before running function under test, body has no div with
-        // default modal id and no table with default table name
-        assert.equal($(modalIdDivSelectorStr).length, 0);
-        assert.equal($(tableIdSelectorStr).length, 0);
+    // before running function under test, body has no div with
+    // default modal id and no table with default table name
+    assert.equal($(modalIdDivSelectorStr).length, 0);
+    assert.equal($(tableIdSelectorStr).length, 0);
 
-        insertPlateModalDiv();
+    insertPlateModalDiv();
 
-        // after running function under test, table has these elements
-        assert.equal($(modalIdDivSelectorStr).length, 1);
-        assert.equal($(tableIdSelectorStr).length, 1);
+    // after running function under test, table has these elements
+    assert.equal($(modalIdDivSelectorStr).length, 1);
+    assert.equal($(tableIdSelectorStr).length, 1);
 
-        // NOTE: unlike python unit tests, qunit does not abort the whole
-        // test case when an assert fails.  Therefore, the cleanup can
-        // simply be done in-line at the end of the test.
-        // Also note that this clean-up can't be done automatically as the dom
-        // objects were added (intentionally) to body rather than to the
-        // qunit-fixture div.
-        $(modalIdDivSelectorStr).remove();
-    });
+    // NOTE: unlike python unit tests, qunit does not abort the whole
+    // test case when an assert fails.  Therefore, the cleanup can
+    // simply be done in-line at the end of the test.
+    // Also note that this clean-up can't be done automatically as the dom
+    // objects were added (intentionally) to body rather than to the
+    // qunit-fixture div.
+    $(modalIdDivSelectorStr).remove();
+  });
 
-    // Verify correct behavior when arguments are explicitly specified
-    QUnit.test("explicit arguments", function (assert) {
-        //explicit names
-        let modalId = 'myModal';
-        let tableId = 'myPlateTable';
-        let parentId = 'qunit-fixture';
+  // Verify correct behavior when arguments are explicitly specified
+  QUnit.test("explicit arguments", function(assert) {
+    //explicit names
+    let modalId = "myModal";
+    let tableId = "myPlateTable";
+    let parentId = "qunit-fixture";
 
-        //jquery selector strings
-        let modalIdDivSelectorStr = "#" + parentId + " div#" + modalId;
-        let tableIdSelectorStr = "#" + parentId + " table#" + tableId;
+    //jquery selector strings
+    let modalIdDivSelectorStr = "#" + parentId + " div#" + modalId;
+    let tableIdSelectorStr = "#" + parentId + " table#" + tableId;
 
-        // before running function under test, qunit-fixture has no div
-        // with explicit modal id and no table with explicit table name
-        assert.equal($(modalIdDivSelectorStr).length, 0);
-        assert.equal($(tableIdSelectorStr).length, 0);
+    // before running function under test, qunit-fixture has no div
+    // with explicit modal id and no table with explicit table name
+    assert.equal($(modalIdDivSelectorStr).length, 0);
+    assert.equal($(tableIdSelectorStr).length, 0);
 
-        insertPlateModalDiv(parentId, modalId, tableId);
+    insertPlateModalDiv(parentId, modalId, tableId);
 
-        // after running function under test, table has these elements
-        assert.equal($(modalIdDivSelectorStr).length, 1);
-        assert.equal($(tableIdSelectorStr).length, 1);
-    });
+    // after running function under test, table has these elements
+    assert.equal($(modalIdDivSelectorStr).length, 1);
+    assert.equal($(tableIdSelectorStr).length, 1);
+  });
 });
 
 // Tests of functions that depend on the plate modal div having already
 // been inserted
-QUnit.module("modal-div-dependent tests", function (hooks) {
-    hooks.beforeEach(function (assert) {
-        insertPlateModalDiv("qunit-fixture");
+QUnit.module("modal-div-dependent tests", function(hooks) {
+  hooks.beforeEach(function(assert) {
+    insertPlateModalDiv("qunit-fixture");
+  });
+
+  // No need for an afterEach hook because the modal div is inserted into
+  // the qunit-fixture div, which QUnit automatically empties after each test
+
+  // Tests of the function populatePlateTable
+  QUnit.module("populatePlateTable", function(hooks) {
+    let qunitTbodySelectorStr = "#qunit-fixture tbody";
+
+    // Verify correct behavior when some realistic plates are input
+    QUnit.test("happy path", function(assert) {
+      let tbodyInnerHtml =
+        '<tr role="row" class="odd"><td ' +
+        'class="sorting_1">33</td><td>Test plate 4</td><' +
+        "td>2019-05-09 21:21:15.386036</td>" +
+        "<td>Identification of the Microbiomes for " +
+        'Cannabis Soils</td><td><button id="addAplate33" ' +
+        'class="btn btn-success btn-circle-small">' +
+        '<span class="glyphicon glyphicon-plus"></span>' +
+        '</button></td></tr><tr role="row" class="even">' +
+        '<td class="sorting_1">30</td><td>Test plate 3</td>' +
+        "<td>2019-05-09 21:21:15.386036</td><td>Identification " +
+        "of the Microbiomes for Cannabis Soils</td><td>" +
+        '<button id="addAplate30" class="btn btn-success ' +
+        'btn-circle-small"><span class="glyphicon ' +
+        'glyphicon-plus"></span></button></td></tr>' +
+        '<tr role="row" class="odd">' +
+        '<td class="sorting_1">27</td><td>Test plate 2</td><' +
+        "td>2019-05-09 21:21:15.386036</td>" +
+        "<td>Identification of the Microbiomes for Cannabis " +
+        'Soils<br>Some other study</td><td><button id="addAplate27" ' +
+        'class="btn btn-success btn-circle-small">' +
+        '<span class="glyphicon glyphicon-plus"></span></button>' +
+        '</td></tr><tr role="row" class="even">' +
+        '<td class="sorting_1">21</td><td>Test plate 1</td>' +
+        "<td>2019-05-09 21:21:15.386036</td>" +
+        "<td>Identification of the Microbiomes for Cannabis " +
+        'Soils</td><td><button id="addAplate21" ' +
+        'class="btn btn-success btn-circle-small"><' +
+        'span class="glyphicon glyphicon-plus"></span></button>' +
+        "</td></tr>";
+      let testPlateInfo = [
+        [
+          21,
+          "Test plate 1",
+          "2019-05-09 21:21:15.386036",
+          ["Identification of the Microbiomes for Cannabis Soils"]
+        ],
+        [
+          27,
+          "Test plate 2",
+          "2019-05-09 21:21:15.386036",
+          [
+            "Identification of the Microbiomes for Cannabis Soils",
+            "Some other study"
+          ]
+        ],
+        [
+          30,
+          "Test plate 3",
+          "2019-05-09 21:21:15.386036",
+          ["Identification of the Microbiomes for Cannabis Soils"]
+        ],
+        [
+          33,
+          "Test plate 4",
+          "2019-05-09 21:21:15.386036",
+          ["Identification of the Microbiomes for Cannabis Soils"]
+        ]
+      ];
+
+      // before running function under test, table has no tbody elements
+      assert.equal($(qunitTbodySelectorStr).length, 0);
+
+      populatePlateTable(testPlateInfo, "#searchPlateTable", "addAplate");
+
+      // after running function under test, table has 1 tbody element
+      // containing rows for 4 plates
+      let tbodysList = $($(qunitTbodySelectorStr));
+      assert.equal(tbodysList.length, 1);
+      assert.equal(tbodysList[0].innerHTML, tbodyInnerHtml);
     });
 
-    // No need for an afterEach hook because the modal div is inserted into
-    // the qunit-fixture div, which QUnit automatically empties after each test
+    // Verify correct behavior when no plates are input
+    QUnit.test("no plates", function(assert) {
+      let tbodyInnerHtml =
+        '<tr class="odd"><td valign="top" ' +
+        'colspan="5" class="dataTables_empty">No data available in ' +
+        "table</td></tr>";
 
-    // Tests of the function populatePlateTable
-    QUnit.module("populatePlateTable", function (hooks) {
-        let qunitTbodySelectorStr = "#qunit-fixture tbody";
+      // before running function under test, table has no tbody elements
+      assert.equal($(qunitTbodySelectorStr).length, 0);
 
-        // Verify correct behavior when some realistic plates are input
-        QUnit.test("happy path", function (assert) {
-            let tbodyInnerHtml = '<tr role="row" class="odd"><td ' +
-                'class="sorting_1">33</td><td>Test plate 4</td><' +
-                'td>2019-05-09 21:21:15.386036</td>' +
-                '<td>Identification of the Microbiomes for ' +
-                'Cannabis Soils</td><td><button id="addAplate33" ' +
-                'class="btn btn-success btn-circle-small">' +
-                '<span class="glyphicon glyphicon-plus"></span>' +
-                '</button></td></tr><tr role="row" class="even">' +
-                '<td class="sorting_1">30</td><td>Test plate 3</td>' +
-                '<td>2019-05-09 21:21:15.386036</td><td>Identification ' +
-                'of the Microbiomes for Cannabis Soils</td><td>' +
-                '<button id="addAplate30" class="btn btn-success ' +
-                'btn-circle-small"><span class="glyphicon ' +
-                'glyphicon-plus"></span></button></td></tr>' +
-                '<tr role="row" class="odd">' +
-                '<td class="sorting_1">27</td><td>Test plate 2</td><' +
-                'td>2019-05-09 21:21:15.386036</td>' +
-                '<td>Identification of the Microbiomes for Cannabis ' +
-                'Soils<br>Some other study</td><td><button id="addAplate27" ' +
-                'class="btn btn-success btn-circle-small">' +
-                '<span class="glyphicon glyphicon-plus"></span></button>' +
-                '</td></tr><tr role="row" class="even">' +
-                '<td class="sorting_1">21</td><td>Test plate 1</td>' +
-                '<td>2019-05-09 21:21:15.386036</td>' +
-                '<td>Identification of the Microbiomes for Cannabis ' +
-                'Soils</td><td><button id="addAplate21" ' +
-                'class="btn btn-success btn-circle-small"><' +
-                'span class="glyphicon glyphicon-plus"></span></button>' +
-                '</td></tr>';
-            let testPlateInfo = [
-                [21, "Test plate 1",
-                    "2019-05-09 21:21:15.386036",
-                    ["Identification of the Microbiomes for Cannabis Soils"]
-                ],
-                [27, "Test plate 2", "2019-05-09 21:21:15.386036",
-                    ["Identification of the Microbiomes for Cannabis Soils",
-                    "Some other study"]
-                ],
-                [30, "Test plate 3", "2019-05-09 21:21:15.386036",
-                    ["Identification of the Microbiomes for Cannabis Soils"]
-                ],
-                [33, "Test plate 4", "2019-05-09 21:21:15.386036",
-                    ["Identification of the Microbiomes for Cannabis Soils"]
-                ]
-            ];
+      populatePlateTable([], "#searchPlateTable", "addAplate");
 
-            // before running function under test, table has no tbody elements
-            assert.equal($(qunitTbodySelectorStr).length, 0);
-
-            populatePlateTable(testPlateInfo, "#searchPlateTable",
-                "addAplate");
-
-            // after running function under test, table has 1 tbody element
-            // containing rows for 4 plates
-            let tbodysList = $($(qunitTbodySelectorStr));
-            assert.equal(tbodysList.length, 1);
-            assert.equal(tbodysList[0].innerHTML, tbodyInnerHtml)
-        });
-
-        // Verify correct behavior when no plates are input
-        QUnit.test("no plates", function (assert) {
-            let tbodyInnerHtml = '<tr class="odd"><td valign="top" ' +
-                'colspan="5" class="dataTables_empty">No data available in ' +
-                'table</td></tr>';
-
-            // before running function under test, table has no tbody elements
-            assert.equal($(qunitTbodySelectorStr).length, 0);
-
-            populatePlateTable([], "#searchPlateTable", "addAplate");
-
-            // after running function under test, table has 1 tbody element
-            // containing a row saying there are no records
-            let tbodysList = $($(qunitTbodySelectorStr));
-            assert.equal(tbodysList.length, 1);
-            assert.equal(tbodysList[0].innerHTML, tbodyInnerHtml)
-        });
+      // after running function under test, table has 1 tbody element
+      // containing a row saying there are no records
+      let tbodysList = $($(qunitTbodySelectorStr));
+      assert.equal(tbodysList.length, 1);
+      assert.equal(tbodysList[0].innerHTML, tbodyInnerHtml);
     });
+  });
 });
-
-

--- a/labcontrol/gui/static/css/labcontrol.css
+++ b/labcontrol/gui/static/css/labcontrol.css
@@ -1,112 +1,114 @@
-body { padding-top: 70px; }
+body {
+  padding-top: 70px;
+}
 
 .dt-selected {
-    background: #D8D8D8;
+  background: #d8d8d8;
 }
 
 /* Well context menu format */
 #wellContextMenu {
-background: #e1efc7;
-border: 1px solid gray;
-padding: 2px;
-display: inline-block;
-min-width: 100px;
--moz-box-shadow: 2px 2px 2px silver;
--webkit-box-shadow: 2px 2px 2px silver;
-z-index: 99999;
+  background: #e1efc7;
+  border: 1px solid gray;
+  padding: 2px;
+  display: inline-block;
+  min-width: 100px;
+  -moz-box-shadow: 2px 2px 2px silver;
+  -webkit-box-shadow: 2px 2px 2px silver;
+  z-index: 99999;
 }
 #wellContextMenu li {
-padding: 4px 4px 4px 14px;
-list-style: none;
-cursor: pointer;
+  padding: 4px 4px 4px 14px;
+  list-style: none;
+  cursor: pointer;
 }
 #wellContextMenu li:hover {
-background-color: white;
+  background-color: white;
 }
 
 #plate-map-legend-commented-box {
-    text-align: center;
+  text-align: center;
 }
 
 /* Wells class */
 
 /* Commented cell (green text) */
 .well-commented {
-    color: green;
+  color: green;
 }
 
 /* Value in cell duplicated on current plate (purple ringed cell) */
 .well-duplicated {
-    border: 2px solid purple;
+  border: 2px solid purple;
 }
 
 /* Value in cell has already been plated on another plate */
 .well-prev-plated {
-    background: repeating-linear-gradient(
-        45deg,
-        #d2dbf2,
-        #d2dbf2 10px,
-        #e3e7ef 10px,
-        #e3e7ef 20px
-        );
+  background: repeating-linear-gradient(
+    45deg,
+    #d2dbf2,
+    #d2dbf2 10px,
+    #e3e7ef 10px,
+    #e3e7ef 20px
+  );
 }
 
 /* Value in cell is not a member of the attached studies */
 .well-unknown {
-    background: repeating-linear-gradient(
-        45deg,
-        #f2a4a4,
-        #f2a4a4 10px,
-        #edc9c9 10px,
-        #edc9c9 20px
-        );
+  background: repeating-linear-gradient(
+    45deg,
+    #f2a4a4,
+    #f2a4a4 10px,
+    #edc9c9 10px,
+    #edc9c9 20px
+  );
 }
 
 /* Value in cell matches one or more members of the attached studies */
 .well-indeterminate {
-    background: repeating-linear-gradient(
-        45deg,
-        #f2f2a4,
-        #f2f2a4 10px,
-        #FFE4B5 10px,
-        #FFE4B5 20px
-        );
+  background: repeating-linear-gradient(
+    45deg,
+    #f2f2a4,
+    #f2f2a4 10px,
+    #ffe4b5 10px,
+    #ffe4b5 20px
+  );
 }
 
 .comment-box {
-    border-style: solid;
-    border-width: 1px;
-    width: 100%;
-    height: 200px;
-    overflow-y: auto;
+  border-style: solid;
+  border-width: 1px;
+  width: 100%;
+  height: 200px;
+  overflow-y: auto;
 }
 
 /* contains all the entries of a legend */
 .legend-container {
-    padding-bottom: 75px;
+  padding-bottom: 75px;
 }
 
 /* contains the elements of a legend entry */
 .legend-entry {
-    padding-left: 10px;
-    padding-bottom: 2.5px;
-    float: left;
-    width: 50%;
+  padding-left: 10px;
+  padding-bottom: 2.5px;
+  float: left;
+  width: 50%;
 }
 
 /* style for a box that can be filled with color for the legend */
 .legend-patch {
-    width: 100px;
-    height: 20px;
-    float: left;
+  width: 100px;
+  height: 20px;
+  float: left;
 }
 
 /* for putting text next to legend-patch */
 .legend-text {
-    /* left margin is the patch width + 10px included to accound for legend-entry */
-    margin-left: 110px;
-    /* 10 additional pixels to move the start of the text further right of the box */
-    padding-left: 10px;
+  /* left margin is the patch width + 10px included to accound for legend-entry */
+  margin-left: 110px;
+  /* 10 additional pixels to move the start of the text further right of the box */
+  padding-left: 10px;
 }
 
 /*
@@ -184,26 +186,26 @@ background-color: white;
 /* Popup style */
 /* Code from https://www.w3schools.com/howto/tryit.asp?filename=tryhow_js_popup */
 .popup {
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
 }
 
 .popup .popuptext {
-    visibility: hidden;
-    color: black;
-    width: 100%;
-    background-color: #bbb;
-    text-align: left;
-    border-radius: 10px;
-    padding: 5px 5px;
-    position: relative;
-    bottom: 10%;
-    right: 0%;
+  visibility: hidden;
+  color: black;
+  width: 100%;
+  background-color: #bbb;
+  text-align: left;
+  border-radius: 10px;
+  padding: 5px 5px;
+  position: relative;
+  bottom: 10%;
+  right: 0%;
 }
 
 .popup .show {
-    visibility: visible;
+  visibility: visible;
 }
 
 /* Make key tags look like buttons, from: */
@@ -215,17 +217,17 @@ kbd.key {
 }
 
 .spreadsheet-container {
-    width: 100%;
-    margin: auto;
-    padding: 10px;
-    padding-bottom: 0px;
+  width: 100%;
+  margin: auto;
+  padding: 10px;
+  padding-bottom: 0px;
 }
 .spreadsheet-frozen-column {
-    /* enough space for one character */
-    width: 22px;
-    float: left;
-    /* disable "hovering" events and other mouse interaction events */
-    pointer-events: none;
+  /* enough space for one character */
+  width: 22px;
+  float: left;
+  /* disable "hovering" events and other mouse interaction events */
+  pointer-events: none;
 }
 
 /* make the header text be fully visible */

--- a/labcontrol/gui/static/js/addPlateModal.js
+++ b/labcontrol/gui/static/js/addPlateModal.js
@@ -9,42 +9,49 @@
 
 // This method creates the plate modal div that is filled and then
 // shown/hidden by other methods in this library
-function insertPlateModalDiv(elementIdToAppendTo = undefined,
-                             addPlateModalId = "addPlateModal",
-                             plateTableId = "searchPlateTable"){
-    let div = $("<div class='modal fade' tabindex='-1' role='dialog' id='" +
-        addPlateModalId + "'>\n" +
-        "  <div class='modal-dialog modal-lg'>\n" +
-        "    <div class='modal-content'>\n" +
-        "      <div class='modal-header'>\n" +
-        "        <button type='button' class='close' data-dismiss='modal' " +
-        "aria-hidden='true'>&times;</button>\n" +
-        "        <h3>Select plate(s) to add</h3>\n" +
-        "      </div>\n" +
-        "      <div class='modal-body'>\n" +
-        "        <table id=\""+ plateTableId + "\" class=\"display\" " +
-        "cellspacing=\"0\" width=\"100%\">\n" +
-        "          <thead>\n" +
-        "            <tr>\n" +
-        "              <th>Plate id</th>\n" +
-        "              <th>Plate name</th>\n" +
-        "              <th>Creation timestamp</th>\n" +
-        "              <th>Studies</th>\n" +
-        "              <th>Add</th>\n" +
-        "            </tr>\n" +
-        "          </thead>\n" +
-        "        </table>\n" +
-        "      </div>\n" +
-        "    </div>\n" +
-        "  </div>\n" +
-        "</div>");
+function insertPlateModalDiv(
+  elementIdToAppendTo = undefined,
+  addPlateModalId = "addPlateModal",
+  plateTableId = "searchPlateTable"
+) {
+  let div = $(
+    "<div class='modal fade' tabindex='-1' role='dialog' id='" +
+      addPlateModalId +
+      "'>\n" +
+      "  <div class='modal-dialog modal-lg'>\n" +
+      "    <div class='modal-content'>\n" +
+      "      <div class='modal-header'>\n" +
+      "        <button type='button' class='close' data-dismiss='modal' " +
+      "aria-hidden='true'>&times;</button>\n" +
+      "        <h3>Select plate(s) to add</h3>\n" +
+      "      </div>\n" +
+      "      <div class='modal-body'>\n" +
+      '        <table id="' +
+      plateTableId +
+      '" class="display" ' +
+      'cellspacing="0" width="100%">\n' +
+      "          <thead>\n" +
+      "            <tr>\n" +
+      "              <th>Plate id</th>\n" +
+      "              <th>Plate name</th>\n" +
+      "              <th>Creation timestamp</th>\n" +
+      "              <th>Studies</th>\n" +
+      "              <th>Add</th>\n" +
+      "            </tr>\n" +
+      "          </thead>\n" +
+      "        </table>\n" +
+      "      </div>\n" +
+      "    </div>\n" +
+      "  </div>\n" +
+      "</div>"
+  );
 
-    let selectorStr = "body";
-    if (elementIdToAppendTo !== undefined){
-        selectorStr = "#" + elementIdToAppendTo
-    }
+  let selectorStr = "body";
+  if (elementIdToAppendTo !== undefined) {
+    selectorStr = "#" + elementIdToAppendTo;
+  }
 
-    div.appendTo($(selectorStr));
+  div.appendTo($(selectorStr));
 }
 
 // This method makes a get call to retrieve a list of information (specified
@@ -57,86 +64,95 @@ function insertPlateModalDiv(elementIdToAppendTo = undefined,
 // the results should be those that have already been quantified,
 // false if all plates of the relevant types should be included.
 function getPlateListPromise(plateTypeList, getOnlyQuantified) {
-    // NB: This does NOT return a list of plate info--instead, it returns a
-    // "promise" that will eventually provide the user access to a list of
-    // plate info--AFTER the asynchronous ajax call is finished, whenever
-    // that turns out to be.
-    return $.ajax({
-        url: '/plate_list',
-        type: 'GET',
-        data: {
-            'plate_type': JSON.stringify(plateTypeList),
-            'only_quantified': getOnlyQuantified
-        }
-    })
-    .fail(function(xhr, ajaxOptions, thrownError){
-        // Probably some more detailed error handling is called for, but
-        // a little is better than none.
-        alert("getPlateListPromise ajax call failed with error " +
-        xhr.status + ": '" + thrownError + "'.");
-    })
+  // NB: This does NOT return a list of plate info--instead, it returns a
+  // "promise" that will eventually provide the user access to a list of
+  // plate info--AFTER the asynchronous ajax call is finished, whenever
+  // that turns out to be.
+  return $.ajax({
+    url: "/plate_list",
+    type: "GET",
+    data: {
+      plate_type: JSON.stringify(plateTypeList),
+      only_quantified: getOnlyQuantified
+    }
+  }).fail(function(xhr, ajaxOptions, thrownError) {
+    // Probably some more detailed error handling is called for, but
+    // a little is better than none.
+    alert(
+      "getPlateListPromise ajax call failed with error " +
+        xhr.status +
+        ": '" +
+        thrownError +
+        "'."
+    );
+  });
 }
 
 /*
-* This method creates and populates a DataTables object with the input
-* plateListInfo, and sets it as the contents of the dom object with the
-* JQuery selector tableSelectorStr (which must already exist in the dom).
-* tableSelectorStr is the string specifying the JQuery selector for the table
-* to be populated, e.g. "#searchPlateTable".
-*
-* plateListInfo is a nested list of the format
-* [
-*   [21, "Test plate 1", "2019-05-09 21:21:15.386036",
-*       ["Identification of the Microbiomes for Cannabis Soils"]
-*   ],
-*   [27, "Test plate 2", "2019-05-09 21:21:15.386036",
-*       ["Identification of the Microbiomes for Cannabis Soils",
-*       "Some Other Qiita Study"]
-*   ]
-*  ]
-* ... where the outer list contains one entry for each plate, which in turn
-* contains four entries: the plate id, the plate external id (e.g., name),
-* the date the plate was created, and a list of the names of all the Qiita
-* studies to which ANY of the samples on the plate belong.
-* specificAddPlateBtnBaseId is the base part--that is, the part that doesn't
-* actually include the plate id--of the the string id for the button one
-* clicks to add a particular, specific plate; e.g., "addBtnPlate".
-*/
-function populatePlateTable(plateListInfo, tableSelectorStr,
-                            specificAddPlateBtnBaseId) {
-    // populate the table of potential plates to add
-    return $(tableSelectorStr).DataTable({
-            'data': plateListInfo,
-            'columnDefs': [
-                {
-                    'targets': -1, // last column
-                    'data': null,
-                    'render': function (data, type, row, meta) {
-                        var plateId = data[0];
-                        return "<button id='" +
-                            specificAddPlateBtnBaseId + plateId +
-                            "' class='btn btn-success btn-circle-small'>" +
-                            "<span class='glyphicon glyphicon-plus'></span>" +
-                            "</button>";
-                    }
-                },
-                {
-                    'targets': -2, // second to last column
-                    'data': null,
-                    'render': function (data, type, row, meta) {
-                        // index 3 in row is the list of studies
-                        return data[3].join('<br/>');
-                    }
-                }
-            ],
-            // per https://datatables.net/reference/option/destroy:
-            // Initialise a new DataTable as usual, but if there is an existing
-            // DataTable which matches the selector, it will be destroyed and
-            // replaced with the new table.
-            'destroy': true,
-            'order': [[0, "desc"]] // order rows in desc order by plate id
+ * This method creates and populates a DataTables object with the input
+ * plateListInfo, and sets it as the contents of the dom object with the
+ * JQuery selector tableSelectorStr (which must already exist in the dom).
+ * tableSelectorStr is the string specifying the JQuery selector for the table
+ * to be populated, e.g. "#searchPlateTable".
+ *
+ * plateListInfo is a nested list of the format
+ * [
+ *   [21, "Test plate 1", "2019-05-09 21:21:15.386036",
+ *       ["Identification of the Microbiomes for Cannabis Soils"]
+ *   ],
+ *   [27, "Test plate 2", "2019-05-09 21:21:15.386036",
+ *       ["Identification of the Microbiomes for Cannabis Soils",
+ *       "Some Other Qiita Study"]
+ *   ]
+ *  ]
+ * ... where the outer list contains one entry for each plate, which in turn
+ * contains four entries: the plate id, the plate external id (e.g., name),
+ * the date the plate was created, and a list of the names of all the Qiita
+ * studies to which ANY of the samples on the plate belong.
+ * specificAddPlateBtnBaseId is the base part--that is, the part that doesn't
+ * actually include the plate id--of the the string id for the button one
+ * clicks to add a particular, specific plate; e.g., "addBtnPlate".
+ */
+function populatePlateTable(
+  plateListInfo,
+  tableSelectorStr,
+  specificAddPlateBtnBaseId
+) {
+  // populate the table of potential plates to add
+  return $(tableSelectorStr).DataTable({
+    data: plateListInfo,
+    columnDefs: [
+      {
+        targets: -1, // last column
+        data: null,
+        render: function(data, type, row, meta) {
+          var plateId = data[0];
+          return (
+            "<button id='" +
+            specificAddPlateBtnBaseId +
+            plateId +
+            "' class='btn btn-success btn-circle-small'>" +
+            "<span class='glyphicon glyphicon-plus'></span>" +
+            "</button>"
+          );
         }
-    );
+      },
+      {
+        targets: -2, // second to last column
+        data: null,
+        render: function(data, type, row, meta) {
+          // index 3 in row is the list of studies
+          return data[3].join("<br/>");
+        }
+      }
+    ],
+    // per https://datatables.net/reference/option/destroy:
+    // Initialise a new DataTable as usual, but if there is an existing
+    // DataTable which matches the selector, it will be destroyed and
+    // replaced with the new table.
+    destroy: true,
+    order: [[0, "desc"]] // order rows in desc order by plate id
+  });
 }
 
 // This method generates a function that, when called, runs addPlate() for a
@@ -152,56 +168,66 @@ function populatePlateTable(plateListInfo, tableSelectorStr,
 // specificAddPlateBtnBaseId is the base part--that is, the part that doesn't
 // actually include the plate id--of the the string id for the button one
 // clicks to add a particular, specific plate; e.g., "addBtnPlate".
-function makeAddSpecificPlateButtonOnclick(dataTable, addPlateModalId,
-                                           specificAddPlateBtnBaseId) {
-    return function () {
-        let plateId = dataTable.row($(this).parents('tr')).data()[0];
-        let addPlateModalSelector = $("#" + addPlateModalId);
-        let addPlateBtnSelector = $("#" + specificAddPlateBtnBaseId + plateId);
+function makeAddSpecificPlateButtonOnclick(
+  dataTable,
+  addPlateModalId,
+  specificAddPlateBtnBaseId
+) {
+  return function() {
+    let plateId = dataTable.row($(this).parents("tr")).data()[0];
+    let addPlateModalSelector = $("#" + addPlateModalId);
+    let addPlateBtnSelector = $("#" + specificAddPlateBtnBaseId + plateId);
 
-        // Hide the modal to add plates
-        addPlateModalSelector.modal('hide');
+    // Hide the modal to add plates
+    addPlateModalSelector.modal("hide");
 
-        // Disable button to add this particular plate while we try to add it
-        addPlateBtnSelector.prop('disabled', true);
+    // Disable button to add this particular plate while we try to add it
+    addPlateBtnSelector.prop("disabled", true);
 
-        try {
-            addPlate(plateId);
-        } catch (e) {
-            // if adding this plate *failed*, re-enable the add plate button
-            // for this plate so the user can try again if they fix their
-            // problem.
-            addPlateBtnSelector.prop('disabled', false);
-        }
+    try {
+      addPlate(plateId);
+    } catch (e) {
+      // if adding this plate *failed*, re-enable the add plate button
+      // for this plate so the user can try again if they fix their
+      // problem.
+      addPlateBtnSelector.prop("disabled", false);
     }
+  };
 }
 
-function setUpAddPlateModal(plateTypeList, getOnlyQuantified,
-                            plateTableId = "searchPlateTable",
-                            addPlateModalId = "addPlateModal",
-                            specificAddPlateBtnBaseId = "addBtnPlate") {
+function setUpAddPlateModal(
+  plateTypeList,
+  getOnlyQuantified,
+  plateTableId = "searchPlateTable",
+  addPlateModalId = "addPlateModal",
+  specificAddPlateBtnBaseId = "addBtnPlate"
+) {
+  // NOTA BENE: ajax calls are asynchronous! (synchronous are deprecated)
+  // This means we don't know when the result will come back and we can't do
+  // ANYTHING that depends on this result--i.e., everything in this function
+  // --until we know it is done.  Failure handling is not specific to this
+  // function so it is specified in getPlateListPromise.
+  getPlateListPromise(plateTypeList, getOnlyQuantified).done(function(data) {
+    //The data come back as in a dictionary object named data, which
+    // contains just one entry--also with the key "data"
+    let plateListInfo = data["data"];
+    let tableSelectorStr = "#" + plateTableId;
+    let table = populatePlateTable(
+      plateListInfo,
+      tableSelectorStr,
+      specificAddPlateBtnBaseId
+    );
 
-    // NOTA BENE: ajax calls are asynchronous! (synchronous are deprecated)
-    // This means we don't know when the result will come back and we can't do
-    // ANYTHING that depends on this result--i.e., everything in this function
-    // --until we know it is done.  Failure handling is not specific to this
-    // function so it is specified in getPlateListPromise.
-    getPlateListPromise(plateTypeList, getOnlyQuantified)
-    .done(function (data) {
-        //The data come back as in a dictionary object named data, which
-        // contains just one entry--also with the key "data"
-        let plateListInfo = (data["data"]);
-        let tableSelectorStr = "#" + plateTableId;
-        let table = populatePlateTable(plateListInfo, tableSelectorStr,
-            specificAddPlateBtnBaseId);
+    let tbodySelector = $(tableSelectorStr + " tbody");
+    // Remove any existing event handler already attached to plate add btns
+    tbodySelector.off("click", "button");
 
-        let tbodySelector = $(tableSelectorStr + ' tbody');
-        // Remove any existing event handler already attached to plate add btns
-        tbodySelector.off('click', 'button');
-
-        // Add function called by clicking on one of the btns that adds a plate
-        let clickAddSpecificPlate = makeAddSpecificPlateButtonOnclick(table,
-            addPlateModalId, specificAddPlateBtnBaseId);
-        tbodySelector.on('click', 'button', clickAddSpecificPlate);
-    });
+    // Add function called by clicking on one of the btns that adds a plate
+    let clickAddSpecificPlate = makeAddSpecificPlateButtonOnclick(
+      table,
+      addPlateModalId,
+      specificAddPlateBtnBaseId
+    );
+    tbodySelector.on("click", "button", clickAddSpecificPlate);
+  });
 }

--- a/labcontrol/gui/static/js/labcontrol.js
+++ b/labcontrol/gui/static/js/labcontrol.js
@@ -3,9 +3,9 @@ var timeoutHandleForBoostrapAlert = null;
 
 // Disable all inputs from a page
 function disableAll() {
-  $('input').prop('disabled', true);
-  $('select').prop('disabled', true);
-  $('button').prop('disabled', true);
+  $("input").prop("disabled", true);
+  $("select").prop("disabled", true);
+  $("button").prop("disabled", true);
 }
 
 /**
@@ -19,105 +19,268 @@ function disableAll() {
  * @param defaultValue string The input default value
  *
  **/
-function createPlateNameInputDOM($targetDiv, plateId, checksCallback, label, defaultValue) {
-  var $rowDiv = $('<div>').addClass('form-group').appendTo($targetDiv);
-  $('<label>').attr('for', 'plate-name-' + plateId).addClass('col-sm-5 control-label').append(label).appendTo($rowDiv);
-  var $colDiv = $('<div>').attr('id', 'div-plate-name-' + plateId).addClass('col-sm-7 has-feedback').appendTo($rowDiv);
-  $('<span>').addClass('glyphicon glyphicon-remove form-control-feedback').appendTo($colDiv);
-  var $inElem = $('<input>').attr('type', 'text').addClass('form-control').attr('id', 'plate-name-' + plateId).val(defaultValue).appendTo($colDiv);
+function createPlateNameInputDOM(
+  $targetDiv,
+  plateId,
+  checksCallback,
+  label,
+  defaultValue
+) {
+  var $rowDiv = $("<div>")
+    .addClass("form-group")
+    .appendTo($targetDiv);
+  $("<label>")
+    .attr("for", "plate-name-" + plateId)
+    .addClass("col-sm-5 control-label")
+    .append(label)
+    .appendTo($rowDiv);
+  var $colDiv = $("<div>")
+    .attr("id", "div-plate-name-" + plateId)
+    .addClass("col-sm-7 has-feedback")
+    .appendTo($rowDiv);
+  $("<span>")
+    .addClass("glyphicon glyphicon-remove form-control-feedback")
+    .appendTo($colDiv);
+  var $inElem = $("<input>")
+    .attr("type", "text")
+    .addClass("form-control")
+    .attr("id", "plate-name-" + plateId)
+    .val(defaultValue)
+    .appendTo($colDiv);
   $inElem.keyup(function(e) {
-    onKeyUpPlateName(e, 'plate-name-' + plateId, checksCallback);
+    onKeyUpPlateName(e, "plate-name-" + plateId, checksCallback);
   });
   $inElem.ready(function() {
-    var e = $.Event('keyup');
-    $('#plate-name-' + plateId).trigger(e);
+    var e = $.Event("keyup");
+    $("#plate-name-" + plateId).trigger(e);
   });
   return $rowDiv;
 }
 
-function createNumberInputDOM($targetDiv, plateId, checksCallback, label, defaultValue, idPrefix, step, minVal) {
-  var $rowDiv = $('<div>').addClass('form-group').appendTo($targetDiv);
-  $('<label>').attr('for', idPrefix + plateId).addClass('col-sm-5 control-label').append(label).appendTo($rowDiv);
-  var $colDiv = $('<div>').addClass('col-sm-7').appendTo($rowDiv);
-  var $inElem = $('<input>').attr('type', 'number').addClass('form-control')
-                            .attr('id', idPrefix + plateId).val(defaultValue)
-                            .appendTo($colDiv).on('change', checksCallback)
-                            .attr('step', step).attr('min', minVal);
+function createNumberInputDOM(
+  $targetDiv,
+  plateId,
+  checksCallback,
+  label,
+  defaultValue,
+  idPrefix,
+  step,
+  minVal
+) {
+  var $rowDiv = $("<div>")
+    .addClass("form-group")
+    .appendTo($targetDiv);
+  $("<label>")
+    .attr("for", idPrefix + plateId)
+    .addClass("col-sm-5 control-label")
+    .append(label)
+    .appendTo($rowDiv);
+  var $colDiv = $("<div>")
+    .addClass("col-sm-7")
+    .appendTo($rowDiv);
+  var $inElem = $("<input>")
+    .attr("type", "number")
+    .addClass("form-control")
+    .attr("id", idPrefix + plateId)
+    .val(defaultValue)
+    .appendTo($colDiv)
+    .on("change", checksCallback)
+    .attr("step", step)
+    .attr("min", minVal);
   return $rowDiv;
 }
 
-function createTextInputDOM($targetDiv, plateId, checksCallback, label, defaultValue, idPrefix) {
-  var $rowDiv = $('<div>').addClass('form-group').appendTo($targetDiv);
-  $('<label>').attr('for', idPrefix + plateId).addClass('col-sm-5 control-label').append(label).appendTo($rowDiv);
-  var $colDiv = $('<div>').addClass('col-sm-7').appendTo($rowDiv);
-  var $inElem = $('<input>').attr('type', 'text').addClass('form-control')
-                            .attr('id', idPrefix + plateId).val(defaultValue)
-                            .appendTo($colDiv).on('change', checksCallback);
+function createTextInputDOM(
+  $targetDiv,
+  plateId,
+  checksCallback,
+  label,
+  defaultValue,
+  idPrefix
+) {
+  var $rowDiv = $("<div>")
+    .addClass("form-group")
+    .appendTo($targetDiv);
+  $("<label>")
+    .attr("for", idPrefix + plateId)
+    .addClass("col-sm-5 control-label")
+    .append(label)
+    .appendTo($rowDiv);
+  var $colDiv = $("<div>")
+    .addClass("col-sm-7")
+    .appendTo($rowDiv);
+  var $inElem = $("<input>")
+    .attr("type", "text")
+    .addClass("form-control")
+    .attr("id", idPrefix + plateId)
+    .val(defaultValue)
+    .appendTo($colDiv)
+    .on("change", checksCallback);
   return $rowDiv;
 }
 
-function createSelectDOM($targetDiv, plateId, checksCallback, label, options, idPrefix, placeholder, idKey) {
+function createSelectDOM(
+  $targetDiv,
+  plateId,
+  checksCallback,
+  label,
+  options,
+  idPrefix,
+  placeholder,
+  idKey
+) {
   if (idKey === undefined) {
-    idKey = 'equipment_id';
+    idKey = "equipment_id";
   }
-  var $rowDiv = $('<div>').addClass('form-group').appendTo($targetDiv);
-  $('<label>').attr('for', idPrefix + plateId).addClass('col-sm-5 control-label').append(label).appendTo($rowDiv);
-  var $colDiv = $('<div>').addClass('col-sm-7').appendTo($rowDiv);
-  var $selElem = $('<select>').addClass('form-control').attr('plate-id', plateId).attr('id', idPrefix + plateId).appendTo($colDiv).on('change', checksCallback);
-  $('<option>').prop('selected', true).prop('disabled', true).append(placeholder).appendTo($selElem);
-  $.each(options, function(idx, elem){
-    $('<option>').attr('value', elem[idKey]).append(elem.external_id).appendTo($selElem)
+  var $rowDiv = $("<div>")
+    .addClass("form-group")
+    .appendTo($targetDiv);
+  $("<label>")
+    .attr("for", idPrefix + plateId)
+    .addClass("col-sm-5 control-label")
+    .append(label)
+    .appendTo($rowDiv);
+  var $colDiv = $("<div>")
+    .addClass("col-sm-7")
+    .appendTo($rowDiv);
+  var $selElem = $("<select>")
+    .addClass("form-control")
+    .attr("plate-id", plateId)
+    .attr("id", idPrefix + plateId)
+    .appendTo($colDiv)
+    .on("change", checksCallback);
+  $("<option>")
+    .prop("selected", true)
+    .prop("disabled", true)
+    .append(placeholder)
+    .appendTo($selElem);
+  $.each(options, function(idx, elem) {
+    $("<option>")
+      .attr("value", elem[idKey])
+      .append(elem.external_id)
+      .appendTo($selElem);
   });
 }
 
-function createCheckboxEnabledSpinner($targetDiv, plateId, checksCallback, label, defaultValue, idPrefix, step, minVal) {
-  var $rowDiv = $('<div>').addClass('form-group').appendTo($targetDiv);
-  $('<label>').addClass('col-sm-5 control-label').append(label).appendTo($rowDiv);
+function createCheckboxEnabledSpinner(
+  $targetDiv,
+  plateId,
+  checksCallback,
+  label,
+  defaultValue,
+  idPrefix,
+  step,
+  minVal
+) {
+  var $rowDiv = $("<div>")
+    .addClass("form-group")
+    .appendTo($targetDiv);
+  $("<label>")
+    .addClass("col-sm-5 control-label")
+    .append(label)
+    .appendTo($rowDiv);
 
-  var $container = $('<div>').addClass('input-group col-sm-2').appendTo($rowDiv);
+  var $container = $("<div>")
+    .addClass("input-group col-sm-2")
+    .appendTo($rowDiv);
 
   // align this input-group with the rest of the form-groups
-  $container.css('padding-left', '15px');
-  var $addon = $('<span>').addClass('input-group-addon').appendTo($container);
-  var $checkbox = $('<input>').attr('type', 'checkbox').appendTo($addon);
-  var $input = $('<input>').attr('type', 'number').addClass('form-control').appendTo($container).on('change', checksCallback);
-  $input.attr('step', step).attr('min', minVal);
-  $input.attr('id', idPrefix + plateId).val(defaultValue);
-  $input.prop('disabled', defaultValue === '');
-  $checkbox.prop('checked', defaultValue !== '');
+  $container.css("padding-left", "15px");
+  var $addon = $("<span>")
+    .addClass("input-group-addon")
+    .appendTo($container);
+  var $checkbox = $("<input>")
+    .attr("type", "checkbox")
+    .appendTo($addon);
+  var $input = $("<input>")
+    .attr("type", "number")
+    .addClass("form-control")
+    .appendTo($container)
+    .on("change", checksCallback);
+  $input.attr("step", step).attr("min", minVal);
+  $input.attr("id", idPrefix + plateId).val(defaultValue);
+  $input.prop("disabled", defaultValue === "");
+  $checkbox.prop("checked", defaultValue !== "");
 
   // enable the input when the checkbox is checked
-  $checkbox.on('change', function(element, event) {
-    $input.prop('disabled', !$checkbox.prop('checked'));
-    if (!$checkbox.prop('checked')) {
-      $input.val(null)
+  $checkbox.on("change", function(element, event) {
+    $input.prop("disabled", !$checkbox.prop("checked"));
+    if (!$checkbox.prop("checked")) {
+      $input.val(null);
     }
     checksCallback();
   });
 }
 
-function createReagentDOM($targetDiv, plateId, checksCallback, label, idPrefix, vueTarget, reagentType) {
-  var $rowDiv = $('<div>').addClass('form-group').appendTo($targetDiv);
-  $('<label>').attr('for', idPrefix + plateId).addClass('col-sm-5 control-label').append(label).appendTo($rowDiv);
-  var $colDiv = $('<div>').addClass('col-sm-7').appendTo($rowDiv);
-  var $inElem = $('<input>').attr('type', 'text').addClass('form-control').attr('id', idPrefix + plateId).appendTo($colDiv);
+function createReagentDOM(
+  $targetDiv,
+  plateId,
+  checksCallback,
+  label,
+  idPrefix,
+  vueTarget,
+  reagentType
+) {
+  var $rowDiv = $("<div>")
+    .addClass("form-group")
+    .appendTo($targetDiv);
+  $("<label>")
+    .attr("for", idPrefix + plateId)
+    .addClass("col-sm-5 control-label")
+    .append(label)
+    .appendTo($rowDiv);
+  var $colDiv = $("<div>")
+    .addClass("col-sm-7")
+    .appendTo($rowDiv);
+  var $inElem = $("<input>")
+    .attr("type", "text")
+    .addClass("form-control")
+    .attr("id", idPrefix + plateId)
+    .appendTo($colDiv);
   // Add the Vue element to the extraction kit once it has been loaded into the DOM.
   // This is needed otherwise Vue will not find the input element
-  $inElem.ready( function() {
-    var vueContainer = $('<div>').attr('id', 'vue-elem-' + idPrefix + plateId).appendTo(vueTarget);
+  $inElem.ready(function() {
+    var vueContainer = $("<div>")
+      .attr("id", "vue-elem-" + idPrefix + plateId)
+      .appendTo(vueTarget);
     var vueComponentCtr = Vue.extend(ReagentModalComponent);
-    var vueElem = new vueComponentCtr({propsData: {'idPrefix': idPrefix + plateId, 'reagentType': reagentType,
-                                                   'inputTarget': idPrefix + plateId, 'checksCallback': checksCallback}});
-    vueElem.$mount('#vue-elem-' + idPrefix + plateId);
+    var vueElem = new vueComponentCtr({
+      propsData: {
+        idPrefix: idPrefix + plateId,
+        reagentType: reagentType,
+        inputTarget: idPrefix + plateId,
+        checksCallback: checksCallback
+      }
+    });
+    vueElem.$mount("#vue-elem-" + idPrefix + plateId);
   });
 }
 
-function createCheckboxDOM($targetDiv, plateId, checksCallback, label, checked, idPrefix) {
-  var $rowDiv = $('<div>').addClass('form-group').appendTo($targetDiv);
-  $('<label>').attr('for', idPrefix + plateId).addClass('col-sm-2 control-label').append(label).appendTo($rowDiv);
-  var $colDiv = $('<div>').addClass('col-sm-10').appendTo($rowDiv);
-  var $inElem = $('<input>').attr('type', 'checkbox').attr('id', idPrefix + plateId).prop('checked', checked)
-                            .appendTo($colDiv).on('change', checksCallback);
+function createCheckboxDOM(
+  $targetDiv,
+  plateId,
+  checksCallback,
+  label,
+  checked,
+  idPrefix
+) {
+  var $rowDiv = $("<div>")
+    .addClass("form-group")
+    .appendTo($targetDiv);
+  $("<label>")
+    .attr("for", idPrefix + plateId)
+    .addClass("col-sm-2 control-label")
+    .append(label)
+    .appendTo($rowDiv);
+  var $colDiv = $("<div>")
+    .addClass("col-sm-10")
+    .appendTo($rowDiv);
+  var $inElem = $("<input>")
+    .attr("type", "checkbox")
+    .attr("id", idPrefix + plateId)
+    .prop("checked", checked)
+    .appendTo($colDiv)
+    .on("change", checksCallback);
 }
 
 /**
@@ -142,42 +305,63 @@ function createCheckboxDOM($targetDiv, plateId, checksCallback, label, checked, 
  **/
 function onKeyUpPlateName(e, input, checksCallback, successCallback) {
   // Check if the new value is the empty string
-  var value = $('#' + input).val().trim()
-  var $div = $('#' + input).closest('div');
+  var value = $("#" + input)
+    .val()
+    .trim();
+  var $div = $("#" + input).closest("div");
 
-  if (value === '') {
-      $div.removeClass('has-success').addClass('has-error').find('span').removeClass('glyphicon-ok').addClass('glyphicon-remove');
-      $('#newNameDivMessage').text('No name specified');
+  if (value === "") {
+    $div
+      .removeClass("has-success")
+      .addClass("has-error")
+      .find("span")
+      .removeClass("glyphicon-ok")
+      .addClass("glyphicon-remove");
+    $("#newNameDivMessage").text("No name specified");
   }
 
-  if (value !== '') {
-    $.get('/platename?new-name=' + value, function (data) {
+  if (value !== "") {
+    $.get("/platename?new-name=" + value, function(data) {
       // If we get here it means that the name already exists
-      $div.removeClass('has-success').addClass('has-error').find('span').removeClass('glyphicon-ok').addClass('glyphicon-remove');
-      $('#newNameDivMessage').text('Name is already used');
+      $div
+        .removeClass("has-success")
+        .addClass("has-error")
+        .find("span")
+        .removeClass("glyphicon-ok")
+        .addClass("glyphicon-remove");
+      $("#newNameDivMessage").text("Name is already used");
       // $('#updateNameBtn').prop('disabled', true);
       checksCallback();
-    })
-      .fail(function (jqXHR, textStatus, errorThrown) {
-        // We need to check the status of the response
-        if(jqXHR.status === 404) {
-          // The plate name doesn't exist - it is ok to change to this name
-          $div.removeClass('has-error').addClass('has-success').find('span').removeClass('glyphicon-remove').addClass('glyphicon-ok');
-          $('#newNameDivMessage').text('Name is available');
-          // $('#updateNameBtn').prop('disabled', false);
-          checksCallback();
-          if(e.which == 13 && successCallback !== undefined) {
-            // This means that the user pressed the enter key
-            // so we will just call the success callback
-            successCallback();
-          }
-        } else {
-          bootstrapAlert(jqXHR.responseText, 'danger');
-          checksCallback();
+    }).fail(function(jqXHR, textStatus, errorThrown) {
+      // We need to check the status of the response
+      if (jqXHR.status === 404) {
+        // The plate name doesn't exist - it is ok to change to this name
+        $div
+          .removeClass("has-error")
+          .addClass("has-success")
+          .find("span")
+          .removeClass("glyphicon-remove")
+          .addClass("glyphicon-ok");
+        $("#newNameDivMessage").text("Name is available");
+        // $('#updateNameBtn').prop('disabled', false);
+        checksCallback();
+        if (e.which == 13 && successCallback !== undefined) {
+          // This means that the user pressed the enter key
+          // so we will just call the success callback
+          successCallback();
         }
-      });
+      } else {
+        bootstrapAlert(jqXHR.responseText, "danger");
+        checksCallback();
+      }
+    });
   } else {
-    $div.removeClass('has-success').addClass('has-error').find('span').removeClass('glyphicon-ok').addClass('glyphicon-remove');
+    $div
+      .removeClass("has-success")
+      .addClass("has-error")
+      .find("span")
+      .removeClass("glyphicon-ok")
+      .addClass("glyphicon-remove");
     // $('#updateNameBtn').prop('disabled', true);
     checksCallback();
   }
@@ -191,32 +375,38 @@ function onKeyUpPlateName(e, input, checksCallback, successCallback) {
  * @param {integer} timeout OPTIONAL. When given, seconds before alert fades out
  *
  **/
-function bootstrapAlert(message, severity, timeout){
-  $('.modal').modal('hide');
+function bootstrapAlert(message, severity, timeout) {
+  $(".modal").modal("hide");
   // make timeout an optional parameter
   timeout = timeout || -1;
   // make severity an optinal parameter
-  severity = typeof severity !== 'undefined' ? severity : 'danger';
+  severity = typeof severity !== "undefined" ? severity : "danger";
   // Remove any previous alert message
   $("#alert-message").remove();
   // Crate the div that contains the message and append the alert message
-  var alertDiv = $('<div>', { 'class': 'alert fade in alert-'+severity, 'role': 'alert', 'id': 'alert-message'})
+  var alertDiv = $("<div>", {
+    class: "alert fade in alert-" + severity,
+    role: "alert",
+    id: "alert-message"
+  })
     .append('<a href="#" class="close" data-dismiss="alert">&times;</a>')
-    .append('<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>')
+    .append(
+      '<span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>'
+    )
     .append(message);
   // Add the alert div just under the navbar
-  $('#template-content').prepend(alertDiv);
+  $("#template-content").prepend(alertDiv);
   // Set a timeout for the alert div if needed
-  if(timeout > 0) {
-   if (timeoutHandleForBoostrapAlert != null) {
-     // This is needed in case that a new alert is generated while
-     // an alert is already shown
-     window.clearTimeout(timeoutHandleForBoostrapAlert);
-   }
-   timeoutHandleForBoostrapAlert = window.setTimeout(function() {
-     $('#alert-message').remove();
-     timeoutHandleForBoostrapAlert = null;
-   }, timeout*1000); // * 1000 to transform from seconds to miliseconds
+  if (timeout > 0) {
+    if (timeoutHandleForBoostrapAlert != null) {
+      // This is needed in case that a new alert is generated while
+      // an alert is already shown
+      window.clearTimeout(timeoutHandleForBoostrapAlert);
+    }
+    timeoutHandleForBoostrapAlert = window.setTimeout(function() {
+      $("#alert-message").remove();
+      timeoutHandleForBoostrapAlert = null;
+    }, timeout * 1000); // * 1000 to transform from seconds to miliseconds
   }
 }
 
@@ -232,13 +422,13 @@ function bootstrapAlert(message, severity, timeout){
  **/
 function getNextRowId(row) {
   var u = row.toUpperCase();
-  if (sameStrChar(u, 'Z')){
-    var txt = '';
+  if (sameStrChar(u, "Z")) {
+    var txt = "";
     var i = u.length;
     while (i--) {
-      txt += 'A';
+      txt += "A";
     }
-    return (txt + 'A');
+    return txt + "A";
   } else {
     var p = "";
     var q = "";
@@ -248,13 +438,13 @@ function getNextRowId(row) {
     }
     var l = u.slice(-1).charCodeAt(0);
     var z = nextLetter(l);
-    if (z === 'A') {
+    if (z === "A") {
       return p.slice(0, -1) + nextLetter(q.slice(-1).charCodeAt(0)) + z;
     } else {
       return p + z;
     }
   }
-};
+}
 
 /**
  *
@@ -270,9 +460,9 @@ function nextLetter(l) {
   if (l < 90) {
     return String.fromCharCode(l + 1);
   } else {
-    return 'A';
+    return "A";
   }
-};
+}
 
 /**
  *
@@ -293,8 +483,7 @@ function sameStrChar(str, char) {
     }
   }
   return true;
-};
-
+}
 
 /**
  *
@@ -304,15 +493,14 @@ function addIfNotPresent(array, elem) {
   if (idx === -1) {
     array.push(elem);
   }
-};
+}
 
 function safeArrayDelete(array, elem) {
   var idx = array.indexOf(elem);
   if (idx !== -1) {
     array.splice(idx, 1);
   }
-};
-
+}
 
 /**
  * Determine an appropriate clipping value for the heatmap's maximum value.
@@ -322,20 +510,17 @@ function safeArrayDelete(array, elem) {
  *
  */
 function clippingForPlateType(plateType) {
-  if (plateType == '16S library prep') {
+  if (plateType == "16S library prep") {
     return 100;
-  }
-  else if (plateType == 'shotgun library prep') {
+  } else if (plateType == "shotgun library prep") {
     return 30;
-  }
-  else if (plateType == 'gDNA' || plateType == 'compressed gDNA plates') {
+  } else if (plateType == "gDNA" || plateType == "compressed gDNA plates") {
     return 20;
   }
 
   // should never get here but if it does, then the range is permissive
   return 10000;
 }
-
 
 /**
  * Create a heatmap with well compositions and a histogram of the DNA
@@ -359,13 +544,18 @@ function clippingForPlateType(plateType) {
  * displayed to use for annotation. If not provided, defaults to "Value"
  *
  */
-function createHeatmap(plateId, concentrations, blanks, names,
-                       defaultClipping, options) {
+function createHeatmap(
+  plateId,
+  concentrations,
+  blanks,
+  names,
+  defaultClipping,
+  options
+) {
+  var colormap = options.colormap || "YlGnBu";
+  var amounts = options.amounts || "Value";
 
-  var colormap = options.colormap || 'YlGnBu';
-  var amounts = options.amounts || 'Value';
-
-  var $container = $('#pool-results-' + plateId);
+  var $container = $("#pool-results-" + plateId);
 
   // existing plot containers need to be removed
   $container.children().remove();
@@ -373,24 +563,24 @@ function createHeatmap(plateId, concentrations, blanks, names,
   var $heatmap = $('<div id="heatmap-' + plateId + '"></div>');
   var $histogram = $('<div id="histogram-' + plateId + '"></div>');
 
-  $heatmap.css({'position': 'relative'});
+  $heatmap.css({ position: "relative" });
 
   var $spinnerContainer = $('<div name="slider-container"></div>');
   var $spinner = $('<input name="clipping-spinner" type="number">');
-  var $label = $('<label>Clip values greater than</label>');
-  var $resetButton = $('<button>reset</button>');
+  var $label = $("<label>Clip values greater than</label>");
+  var $resetButton = $("<button>reset</button>");
 
   $label.append($spinner);
   $spinnerContainer.append($label);
-  $spinnerContainer.append('<br>');
+  $spinnerContainer.append("<br>");
   $spinnerContainer.append($resetButton);
   $spinnerContainer.css({
-    'width': '200px',
-    'height': '100px',
-    'position': 'absolute',
-    'top': '0',
-    'left': '20px',
-    'z-index': '10'
+    width: "200px",
+    height: "100px",
+    position: "absolute",
+    top: "0",
+    left: "20px",
+    "z-index": "10"
   });
 
   $heatmap.append($spinnerContainer);
@@ -404,47 +594,60 @@ function createHeatmap(plateId, concentrations, blanks, names,
   concentrations = concentrations.reverse();
   names = names.reverse();
 
-  var letters = 'ABCDEFGHIJKLMPNOPQRSTUVWXYZ'.split(''), yLabels;
+  var letters = "ABCDEFGHIJKLMPNOPQRSTUVWXYZ".split(""),
+    yLabels;
   yLabels = letters.slice(0, concentrations.length);
   yLabels = yLabels.reverse();
 
   var minConcentration = 0;
-  var hoverlabels = [], annotations = [], result;
-  var flattenedBlanks = [], flattenedNonBlanks = [];
+  var hoverlabels = [],
+    annotations = [],
+    result;
+  var flattenedBlanks = [],
+    flattenedNonBlanks = [];
 
   // this double loop will construct the arrays necessary for the histogram
   // and the heatmap (including annotations, and legends)
-  for (var i = 0; i<names.length; i++){
+  for (var i = 0; i < names.length; i++) {
     hoverlabels[i] = [];
-    for (var j =0; j<names[0].length; j++){
-
+    for (var j = 0; j < names[0].length; j++) {
       // per-well annotations on the cells, indicate with a special character
       // when the well represents a blank sample
       result = {
         x: j + 1,
         y: yLabels[i],
-        text: blanks[i][j] ? '🔳' : '',
+        text: blanks[i][j] ? "🔳" : "",
         showarrow: false
-      }
+      };
       annotations.push(result);
 
       // per-well labels
-      hoverlabels[i].push("Row : " + yLabels[i] + " Column : " + (j+1) +
-                          " <br>" + amounts + " : " + concentrations[i][j] +
-                          " <br> Sample Name : " +
-                          (names[i][j] == null ? 'Not Available':  names[i][j]));
+      hoverlabels[i].push(
+        "Row : " +
+          yLabels[i] +
+          " Column : " +
+          (j + 1) +
+          " <br>" +
+          amounts +
+          " : " +
+          concentrations[i][j] +
+          " <br> Sample Name : " +
+          (names[i][j] == null ? "Not Available" : names[i][j])
+      );
 
       // split the concentrations to show different colors in the histogram
       if (blanks[i][j] === true) {
         flattenedBlanks.push(concentrations[i][j]);
-      }
-      else {
+      } else {
         flattenedNonBlanks.push(concentrations[i][j]);
       }
     }
   }
 
-  minConcentration = Math.min.apply(null, flattenedBlanks.concat(flattenedNonBlanks))
+  minConcentration = Math.min.apply(
+    null,
+    flattenedBlanks.concat(flattenedNonBlanks)
+  );
 
   // setup the plotly definitions
   var heatmapData = [
@@ -453,12 +656,12 @@ function createHeatmap(plateId, concentrations, blanks, names,
       y: yLabels,
       z: concentrations,
       text: hoverlabels,
-      hoverinfo: 'text',
-      type: 'heatmap',
+      hoverinfo: "text",
+      type: "heatmap",
       colorscale: colormap,
-      colorbar:{
+      colorbar: {
         title: amounts,
-        titleside:'top',
+        titleside: "top"
       },
       xgap: 1,
       ygap: 1,
@@ -468,75 +671,74 @@ function createHeatmap(plateId, concentrations, blanks, names,
   ];
 
   // make each cell a square
-  var heatwidth = (600/yLabels.length)*names[0].length;
+  var heatwidth = (600 / yLabels.length) * names[0].length;
   var heatmapLayout = {
     autosize: false,
     height: 600,
     width: heatwidth,
     xaxis: {
-      autotick:false,
-      side:'top'
+      autotick: false,
+      side: "top"
     },
     annotations: annotations,
-    title: 'Per-well ' + amounts
+    title: "Per-well " + amounts
   };
 
   var nonBlankData = {
     name: "Non-Blank",
     x: flattenedNonBlanks,
-    type: 'histogram',
-    marker:  {
-    color: "rgba(27, 158, 119, 1)",
+    type: "histogram",
+    marker: {
+      color: "rgba(27, 158, 119, 1)",
       line: {
         color: "rgba(27, 158, 119, 1)",
         width: 5
-        }
-     },
+      }
+    }
   };
   var blankData = {
     name: "Blank",
     x: flattenedBlanks,
-    type: 'histogram',
-    marker:  {
-    color: "rgba(217, 95, 2, 1)",
+    type: "histogram",
+    marker: {
+      color: "rgba(217, 95, 2, 1)",
       line: {
         color: "rgba(217, 95, 2, 1)",
         width: 5
-        }
-     },
+      }
+    }
   };
   var histogramLayout = {
     autosize: false,
     width: heatwidth,
-    xaxis: {title: amounts},
-    yaxis: {title: "Number Samples"},
-    title: amounts + ' Distribution'
+    xaxis: { title: amounts },
+    yaxis: { title: "Number Samples" },
+    title: amounts + " Distribution"
   };
   var histogramData = [nonBlankData, blankData];
 
   // if a plot exists with this id it should be removed
-  Plotly.purge($heatmap.attr('id'));
-  Plotly.purge($histogram.attr('id'));
+  Plotly.purge($heatmap.attr("id"));
+  Plotly.purge($histogram.attr("id"));
 
-  Plotly.plot($heatmap.attr('id'), heatmapData, heatmapLayout);
-  Plotly.plot($histogram.attr('id'), histogramData, histogramLayout);
+  Plotly.plot($heatmap.attr("id"), heatmapData, heatmapLayout);
+  Plotly.plot($histogram.attr("id"), histogramData, histogramLayout);
 
   // setup some interactivity to clip the values in the histogram
   $(function() {
-    var text = 'Clip values greater than ';
+    var text = "Clip values greater than ";
 
     // pad the minimum so the colorscale doesn't error
     $spinner.val(defaultClipping);
-    $spinner.attr('min', minConcentration + 1);
-    $spinner.on('input', function(a, b) {
+    $spinner.attr("min", minConcentration + 1);
+    $spinner.on("input", function(a, b) {
       var clipping = parseFloat($spinner.val());
-      Plotly.update($heatmap.attr('id'), {zmax: clipping}, 0);
+      Plotly.update($heatmap.attr("id"), { zmax: clipping }, 0);
     });
 
-    $resetButton.on('click', function() {
+    $resetButton.on("click", function() {
       $spinner.val(defaultClipping);
-      Plotly.update($heatmap.attr('id'), {zmax: defaultClipping}, 0);
+      Plotly.update($heatmap.attr("id"), { zmax: defaultClipping }, 0);
     });
   });
-
-};
+}

--- a/labcontrol/gui/static/js/plate.js
+++ b/labcontrol/gui/static/js/plate.js
@@ -4,37 +4,43 @@
  *
  **/
 function change_plate_name() {
-  $('#updateNameBtn').prop('disabled', true).find('span').addClass('glyphicon glyphicon-refresh gly-spin');
-  $('#newNameInput').prop('disabled', true);
-  var value = $('#newNameInput').val().trim();
-  var plateId = $('#plateName').prop('pm-data-plate-id');
+  $("#updateNameBtn")
+    .prop("disabled", true)
+    .find("span")
+    .addClass("glyphicon glyphicon-refresh gly-spin");
+  $("#newNameInput").prop("disabled", true);
+  var value = $("#newNameInput")
+    .val()
+    .trim();
+  var plateId = $("#plateName").prop("pm-data-plate-id");
   if (plateId !== undefined) {
     // Modifying a plate that already exists, ask the server to change the
     // plate configuration
-    $.ajax({url: '/plate/' + plateId + '/',
-           type: 'PATCH',
-           data: {'op': 'replace', 'path': '/name', 'value': value},
-           success: function (data) {
-             $('#plateName').html(value);
-             $('#updatePlateName').modal('hide');
-          },
-          error: function (jqXHR, textStatus, errorThrown) {
-            bootstrapAlert(jqXHR.responseText, 'danger');
-            $('#updatePlateName').modal('hide');
-          }
+    $.ajax({
+      url: "/plate/" + plateId + "/",
+      type: "PATCH",
+      data: { op: "replace", path: "/name", value: value },
+      success: function(data) {
+        $("#plateName").html(value);
+        $("#updatePlateName").modal("hide");
+      },
+      error: function(jqXHR, textStatus, errorThrown) {
+        bootstrapAlert(jqXHR.responseText, "danger");
+        $("#updatePlateName").modal("hide");
+      }
     });
   } else {
-    $('#plateName').html(value);
-    $('#updatePlateName').modal('hide');
+    $("#plateName").html(value);
+    $("#updatePlateName").modal("hide");
   }
   // This is only needed when the modal was open for first time automatically when
   // creating a new plate. However, it doesn't hurt having it here executed always
-  $('#updatePlateNameCloseBtn').prop('hidden', false);
-  $('#updatePlateName').data('bs.modal').options.keyboard = true;
-  $('#updatePlateName').data('bs.modal').options.backdrop = true;
+  $("#updatePlateNameCloseBtn").prop("hidden", false);
+  $("#updatePlateName").data("bs.modal").options.keyboard = true;
+  $("#updatePlateName").data("bs.modal").options.backdrop = true;
   // Remove the cancel button from the modal
-  $('#cancelUpdateNameBtn').remove();
-};
+  $("#cancelUpdateNameBtn").remove();
+}
 
 /**
  *
@@ -44,35 +50,38 @@ function change_plate_name() {
  *
  **/
 function add_study(studyId) {
-  $.get('/study/' + studyId + '/', function (data) {
+  $.get("/study/" + studyId + "/", function(data) {
     // Create the element containing the study information and add it to the list
     var $aElem = $("<a href='#' onclick='activate_study(" + studyId + ")'>");
-    $aElem.addClass('list-group-item').addClass('study-list-item');
-    $aElem.attr('id', 'study-' + studyId);
-    $aElem.attr('pm-data-study-id', studyId);
-    $aElem.append('<label><h4>' + data.study_title + '</h4></label>');
-    $aElem.append(' Total Samples: ' + data.total_samples);
-    var $buttonElem = $("<button class='btn btn-danger btn-circle pull-right' onclick='remove_study(" + studyId + ");'>");
-    $buttonElem.append("<span class='glyphicon glyphicon-remove'></span>")
+    $aElem.addClass("list-group-item").addClass("study-list-item");
+    $aElem.attr("id", "study-" + studyId);
+    $aElem.attr("pm-data-study-id", studyId);
+    $aElem.append("<label><h4>" + data.study_title + "</h4></label>");
+    $aElem.append(" Total Samples: " + data.total_samples);
+    var $buttonElem = $(
+      "<button class='btn btn-danger btn-circle pull-right' onclick='remove_study(" +
+        studyId +
+        ");'>"
+    );
+    $buttonElem.append("<span class='glyphicon glyphicon-remove'></span>");
     $aElem.append($buttonElem);
 
-    $('#study-list').append($aElem);
+    $("#study-list").append($aElem);
 
-    if($('#study-list').children().length === 1) {
-        activate_study(studyId);
+    if ($("#study-list").children().length === 1) {
+      activate_study(studyId);
     }
 
     // Disable the button to add the study to the list
-    $('#addBtnStudy' + studyId).prop('disabled', true);
+    $("#addBtnStudy" + studyId).prop("disabled", true);
 
     // Hide the modal to add studies
-    $('#addStudyModal').modal('hide');
-  })
-    .fail(function (jqXHR, textStatus, errorThrown) {
-      bootstrapAlert(jqXHR.responseText, 'danger');
-      $('#addStudyModal').modal('hide');
-    });
-};
+    $("#addStudyModal").modal("hide");
+  }).fail(function(jqXHR, textStatus, errorThrown) {
+    bootstrapAlert(jqXHR.responseText, "danger");
+    $("#addStudyModal").modal("hide");
+  });
+}
 
 /**
  *
@@ -83,21 +92,24 @@ function add_study(studyId) {
  **/
 function remove_study(studyId) {
   // Remove the study from the list:
-  $('#study-' + studyId).remove();
+  $("#study-" + studyId).remove();
   // Re-enable the button to add the study to the list
-  $('#addBtnStudy' + studyId).prop('disabled', false);
+  $("#addBtnStudy" + studyId).prop("disabled", false);
 }
 
 function activate_study(studyId) {
-  var $elem = $('#study-' + studyId);
-  if ($elem.hasClass('active')) {
+  var $elem = $("#study-" + studyId);
+  if ($elem.hasClass("active")) {
     // If the current element already has the active class, remove it,
     // so no study is active
-    $elem.removeClass('active');
+    $elem.removeClass("active");
   } else {
     // Otherwise choose the curernt study as the active
-    $elem.parent().find('a').removeClass('active');
-    $elem.addClass('active');
+    $elem
+      .parent()
+      .find("a")
+      .removeClass("active");
+    $elem.addClass("active");
   }
 }
 
@@ -108,66 +120,82 @@ function activate_study(studyId) {
  **/
 function change_plate_configuration() {
   var pv, $opt;
-  $opt = $('#plate-conf-select option:selected');
-  var plateId = $('#plateName').prop('pm-data-plate-id');
+  $opt = $("#plate-conf-select option:selected");
+  var plateId = $("#plateName").prop("pm-data-plate-id");
   if (plateId !== undefined) {
-    throw "Can't change the plate configuration of an existing plate"
+    throw "Can't change the plate configuration of an existing plate";
   } else {
     // reset the container before updating the grid configuration
-    $('#plate-map-div').empty().height(0);
+    $("#plate-map-div")
+      .empty()
+      .height(0);
     // Enable the plate create button now that a plate config is selected
-    $('#createPlateBtn').prop('disabled', false);
+    $("#createPlateBtn").prop("disabled", false);
   }
 }
 
 /**
  * Callback from the "Create" button in the sample plating page.
  */
-function createPlate(){
-  $('#createPlateBtn').prop('disabled', true);
+function createPlate() {
+  $("#createPlateBtn").prop("disabled", true);
 
-  var plateName = $('#newNameInput').val().trim();
-  var plateConf = $('#plate-conf-select option:selected').val();
+  var plateName = $("#newNameInput")
+    .val()
+    .trim();
+  var plateConf = $("#plate-conf-select option:selected").val();
 
-  $.post(
-    '/process/sample_plating',
-    {'plate_name': plateName, 'plate_configuration': plateConf}
-  )
-  .done(function (data) {
-    var plateId = data['plate_id'];
-    var processId = data['process_id'];
-
-    $('#plateName').prop('pm-data-plate-id', plateId);
-    $('#plateName').prop('pm-data-process-id', processId);
-    // Once the plate has been created, we can disable the plate config select
-    $('#plate-conf-select').prop('disabled', true);
-
-    // reset the container before updating the grid configuration
-    $('#plate-map-div').empty().height(0);
-    var $opt = $('#plate-conf-select option:selected');
-
-    // Create a new PlateViewer object *without* passing in plateId and
-    // processId, because if those are passed in to the object initializer,
-    // code assumes the plate has already been filled--and when it can't find
-    // contents, it populates all the wells with blanks :(.  Setting the
-    // plateId and processId after object initialization sets the necessary
-    // state but avoids this behavior.
-    var pv = new PlateViewer('plate-map-div', undefined, undefined, $opt.attr('pm-data-rows'), $opt.attr('pm-data-cols'));
-    pv.plateId = plateId;
-    pv.processId = processId;
-    // we can only instantiate the notes box when we have a process id
-    pv.notes = new NotesBox(pv.container.parent(),
-                            '/process/sample_plating/notes',
-                            processId);
-
-    // Disable the plate create button
-    $('#createPlateBtn').prop('disabled', true);
-
-    // Show the plate details div
-    $('#plateDetails').prop('hidden', false);
+  $.post("/process/sample_plating", {
+    plate_name: plateName,
+    plate_configuration: plateConf
   })
-  .fail(function(jqXHR, textStatus, errorThrown) {
-    $('#createPlateBtn').prop('disabled', false);
-    bootstrapAlert('Could not create plate. Error message:<br>' + jqXHR.responseText);
-  });
+    .done(function(data) {
+      var plateId = data["plate_id"];
+      var processId = data["process_id"];
+
+      $("#plateName").prop("pm-data-plate-id", plateId);
+      $("#plateName").prop("pm-data-process-id", processId);
+      // Once the plate has been created, we can disable the plate config select
+      $("#plate-conf-select").prop("disabled", true);
+
+      // reset the container before updating the grid configuration
+      $("#plate-map-div")
+        .empty()
+        .height(0);
+      var $opt = $("#plate-conf-select option:selected");
+
+      // Create a new PlateViewer object *without* passing in plateId and
+      // processId, because if those are passed in to the object initializer,
+      // code assumes the plate has already been filled--and when it can't find
+      // contents, it populates all the wells with blanks :(.  Setting the
+      // plateId and processId after object initialization sets the necessary
+      // state but avoids this behavior.
+      var pv = new PlateViewer(
+        "plate-map-div",
+        undefined,
+        undefined,
+        $opt.attr("pm-data-rows"),
+        $opt.attr("pm-data-cols")
+      );
+      pv.plateId = plateId;
+      pv.processId = processId;
+      // we can only instantiate the notes box when we have a process id
+      pv.notes = new NotesBox(
+        pv.container.parent(),
+        "/process/sample_plating/notes",
+        processId
+      );
+
+      // Disable the plate create button
+      $("#createPlateBtn").prop("disabled", true);
+
+      // Show the plate details div
+      $("#plateDetails").prop("hidden", false);
+    })
+    .fail(function(jqXHR, textStatus, errorThrown) {
+      $("#createPlateBtn").prop("disabled", false);
+      bootstrapAlert(
+        "Could not create plate. Error message:<br>" + jqXHR.responseText
+      );
+    });
 }

--- a/labcontrol/gui/static/js/plateViewer.js
+++ b/labcontrol/gui/static/js/plateViewer.js
@@ -14,7 +14,7 @@
  *
  **/
 function PlateViewer(target, plateId, processId, rows, cols) {
-  this.container = $('#' + target);
+  this.container = $("#" + target);
 
   /*
    * HACK: SlickGrid doesn't currently support frozen columns hence we are
@@ -23,8 +23,9 @@ function PlateViewer(target, plateId, processId, rows, cols) {
    * this GitHub issue: https://github.com/6pac/SlickGrid/issues/26
    */
   this.target = $('<div name="main-grid"></div>');
-  this._frozenColumnTarget = $('<div name="frozen-column" ' +
-                               'class="spreadsheet-frozen-column"></div>');
+  this._frozenColumnTarget = $(
+    '<div name="frozen-column" ' + 'class="spreadsheet-frozen-column"></div>'
+  );
 
   this.container.append(this._frozenColumnTarget);
   this.container.append(this.target);
@@ -39,7 +40,9 @@ function PlateViewer(target, plateId, processId, rows, cols) {
   if (!plateId) {
     if (!rows || !cols) {
       // This error should never show up in production
-      bootstrapAlert('PlateViewer developer error: rows and cols should be provided if plateId is not provided');
+      bootstrapAlert(
+        "PlateViewer developer error: rows and cols should be provided if plateId is not provided"
+      );
     } else {
       this.initialize(rows, cols);
     }
@@ -48,36 +51,35 @@ function PlateViewer(target, plateId, processId, rows, cols) {
     // information and initialize the object
     this.plateId = plateId;
     this.processId = processId;
-    $.get('/plate/' + this.plateId + '/', function (data) {
+    $.get("/plate/" + this.plateId + "/", function(data) {
       var rows, cols, pcId;
       // Magic numbers. The plate configuration is a list of elements
       // Element 2 -> number of rows
       // Element 3 -> number of cols
-      rows = data['plate_configuration'][2];
-      cols = data['plate_configuration'][3];
-      $.each(data['studies'], function (idx, elem){
+      rows = data["plate_configuration"][2];
+      cols = data["plate_configuration"][3];
+      $.each(data["studies"], function(idx, elem) {
         add_study(elem);
       });
       that.initialize(rows, cols);
-      $.each(data['duplicates'], function(idx, elem) {
-        that.wellClasses[elem[0] - 1][elem[1] - 1].push('well-duplicated');
+      $.each(data["duplicates"], function(idx, elem) {
+        that.wellClasses[elem[0] - 1][elem[1] - 1].push("well-duplicated");
       });
-      $.each(data['previous_plates'], function(idx, elem) {
+      $.each(data["previous_plates"], function(idx, elem) {
         var r = elem[0][0] - 1;
         var c = elem[0][1] - 1;
         that.wellPreviousPlates[r][c] = elem[1];
-        that.wellClasses[r][c].push('well-prev-plated');
+        that.wellClasses[r][c].push("well-prev-plated");
       });
-      $.each(data['unknowns'], function(idx, elem) {
-        that.wellClasses[elem[0] - 1][elem[1] - 1].push('well-unknown');
+      $.each(data["unknowns"], function(idx, elem) {
+        that.wellClasses[elem[0] - 1][elem[1] - 1].push("well-unknown");
       });
       that.loadPlateLayout();
-    })
-      .fail(function (jqXHR, textStatus, errorThrown) {
-        bootstrapAlert(jqXHR.responseText, 'danger');
-      });
+    }).fail(function(jqXHR, textStatus, errorThrown) {
+      bootstrapAlert(jqXHR.responseText, "danger");
+    });
   }
-};
+}
 
 /**
  *
@@ -87,9 +89,9 @@ function PlateViewer(target, plateId, processId, rows, cols) {
  * @param {int} cols The number of columns
  *
  **/
-PlateViewer.prototype.initialize = function (rows, cols) {
+PlateViewer.prototype.initialize = function(rows, cols) {
   var that = this;
-  var height = '250px';
+  var height = "250px";
 
   this.rows = rows;
   this.cols = cols;
@@ -102,44 +104,55 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   // Make sure all rows fit on screen. we need to have enough space so that we
   // don't have to synchronize the scrolling events between the two elements
   if (rows > 8) {
-    height = '450px';
+    height = "450px";
   }
   this.container.height(height);
   this.target.height(height);
   this._frozenColumnTarget.height(height);
 
-  var sgOptions = {editable: true,
-                   enableCellNavigation: true,
-                   asyncEditorLoading: false,
-                   enableColumnReorder: false,
-                   autoEdit: true,
-                   resizable: true};
+  var sgOptions = {
+    editable: true,
+    enableCellNavigation: true,
+    asyncEditorLoading: false,
+    enableColumnReorder: false,
+    autoEdit: true,
+    resizable: true
+  };
 
-  var frozenColumnOptions = {editable: false,
-                             enableCellNavigation: false,
-                             enableColumnReorder: false,
-                             autoEdit: false};
+  var frozenColumnOptions = {
+    editable: false,
+    enableCellNavigation: false,
+    enableColumnReorder: false,
+    autoEdit: false
+  };
 
   // Use the slick-header-column but with mouse events disabled
   // Without the &nbsp; the header will be smaller than for the main grid
-  var frozenColumn = [{id: 'selector',
-                       name: '&nbsp;',
-                       field: 'header',
-                       width: 22,
-                       cssClass: 'slick-header-column',
-                       headerCssClass: 'full-height-header'}];
+  var frozenColumn = [
+    {
+      id: "selector",
+      name: "&nbsp;",
+      field: "header",
+      width: 22,
+      cssClass: "slick-header-column",
+      headerCssClass: "full-height-header"
+    }
+  ];
 
   // Fetch the blank names before initializing the grid. This way we only make
   // one request to get this data instead of one per cell instantiation.
   // When no search term is specified in the request, we get all available
   // blank types.
   var blanksRequest = $.get({
-    dataType: 'json',
-    url: '/sample/control?term=',
+    dataType: "json",
+    url: "/sample/control?term=",
     error: function(jqXHR, textStatus, errorThrown) {
-     bootstrapAlert('Could not fetch known <i>Control Types</i> needed for ' +
-                    'plating samples. Try reloading the page. <br>' +
-                    jqXHR.responseText, 'danger');
+      bootstrapAlert(
+        "Could not fetch known <i>Control Types</i> needed for " +
+          "plating samples. Try reloading the page. <br>" +
+          jqXHR.responseText,
+        "danger"
+      );
     }
   });
 
@@ -151,16 +164,17 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     sgCols.push({
       plateViewer: this,
       id: i,
-      name: i+1,
+      name: i + 1,
       field: i,
       editor: SampleCellEditor,
-      options: {'blankNamesRequest': blanksRequest},
+      options: { blankNamesRequest: blanksRequest },
       formatter: this.wellFormatter,
-      width:100,
+      width: 100,
       minWidth: 80,
-      headerCssClass: 'full-height-header'});
+      headerCssClass: "full-height-header"
+    });
   }
-  var rowId = 'A';
+  var rowId = "A";
 
   for (var i = 0; i < this.rows; i++) {
     var d = (this.data[i] = {});
@@ -168,7 +182,7 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     var cl = (this.wellClasses[i] = {});
     var pp = (this.wellPreviousPlates[i] = {});
 
-    this.frozenData.push({'header': rowId});
+    this.frozenData.push({ header: rowId });
 
     for (var j = 0; j < this.cols; j++) {
       d[j] = null;
@@ -179,37 +193,38 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     rowId = getNextRowId(rowId);
   }
 
-
   /*
    * Taken from the example here:
    * https://github.com/6pac/SlickGrid/blob/master/examples/example-excel-compatible-spreadsheet.html
    */
   this._undoRedoBuffer = {
-      commandQueue : [],
-      commandCtr : 0,
-      queueAndExecuteCommand : function(editCommand) {
-        this.commandQueue[this.commandCtr] = editCommand;
-        this.commandCtr++;
-        editCommand.execute();
-      },
-      undo : function() {
-        if (this.commandCtr == 0) {
-          return;
-        }
-        this.commandCtr--;
-        var command = this.commandQueue[this.commandCtr];
-        if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
-          command.undo();
-        }
-      },
-      redo : function() {
-        if (this.commandCtr >= this.commandQueue.length) { return; }
-        var command = this.commandQueue[this.commandCtr];
-        this.commandCtr++;
-        if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
-          command.execute();
-        }
+    commandQueue: [],
+    commandCtr: 0,
+    queueAndExecuteCommand: function(editCommand) {
+      this.commandQueue[this.commandCtr] = editCommand;
+      this.commandCtr++;
+      editCommand.execute();
+    },
+    undo: function() {
+      if (this.commandCtr == 0) {
+        return;
       }
+      this.commandCtr--;
+      var command = this.commandQueue[this.commandCtr];
+      if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
+        command.undo();
+      }
+    },
+    redo: function() {
+      if (this.commandCtr >= this.commandQueue.length) {
+        return;
+      }
+      var command = this.commandQueue[this.commandCtr];
+      this.commandCtr++;
+      if (command && Slick.GlobalEditorLock.cancelCurrentEdit()) {
+        command.execute();
+      }
+    }
   };
 
   var sgOptions = {
@@ -219,15 +234,15 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     enableColumnReorder: false,
     autoEdit: true,
     editCommandHandler: function(item, column, editCommand) {
-     that._undoRedoBuffer.queueAndExecuteCommand(editCommand);
+      that._undoRedoBuffer.queueAndExecuteCommand(editCommand);
     }
   };
 
   // Handle the callbacks to CTRL + Z and CTRL + SHIFT + Z
-  $(document).keydown(function(e)
-  {
-    if (e.which == 90 && (e.ctrlKey || e.metaKey)) {    // CTRL + (shift) + Z
-      if (e.shiftKey){
+  $(document).keydown(function(e) {
+    if (e.which == 90 && (e.ctrlKey || e.metaKey)) {
+      // CTRL + (shift) + Z
+      if (e.shiftKey) {
         that._undoRedoBuffer.redo();
       } else {
         that._undoRedoBuffer.undo();
@@ -236,26 +251,35 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     // ESC enters selection mode, so autoEdit should be turned off to allow
     // users to navigate between cells with the arrow keys
     if (e.keyCode === 27) {
-      that.grid.setOptions({autoEdit: false});
+      that.grid.setOptions({ autoEdit: false });
     }
   });
 
   var pluginOptions = {
-    clipboardCommandHandler: function(editCommand){
-      that._undoRedoBuffer.queueAndExecuteCommand.call(that._undoRedoBuffer,editCommand);
+    clipboardCommandHandler: function(editCommand) {
+      that._undoRedoBuffer.queueAndExecuteCommand.call(
+        that._undoRedoBuffer,
+        editCommand
+      );
     },
-    readOnlyMode : false,
-    includeHeaderWhenCopying : false
+    readOnlyMode: false,
+    includeHeaderWhenCopying: false
   };
 
-  this._frozenColumn = new Slick.Grid(this._frozenColumnTarget, this.frozenData,
-                                      frozenColumn, frozenColumnOptions);
+  this._frozenColumn = new Slick.Grid(
+    this._frozenColumnTarget,
+    this.frozenData,
+    frozenColumn,
+    frozenColumnOptions
+  );
   this.grid = new Slick.Grid(this.target, this.data, sgCols, sgOptions);
 
   // don't select the active cell, otherwise cell navigation won't work
-  this.grid.setSelectionModel(new Slick.CellSelectionModel({selectActiveCell: false}));
+  this.grid.setSelectionModel(
+    new Slick.CellSelectionModel({ selectActiveCell: false })
+  );
 
-  $('#multiSelectCheckbox').on('change', function() {
+  $("#multiSelectCheckbox").on("change", function() {
     // In this callback function, "this" is the m.s. checkbox's <input> element
     // "that" is defined as this (see the start of this function), which lets
     // us refer to this particular PlateViewer object from within callback
@@ -270,7 +294,9 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   });
   // This paradigm inspired by
   // https://github.com/mleibman/SlickGrid/blob/master/examples/example-spreadsheet.html
-  this.cellExternalCopyManager = new Slick.CellExternalCopyManager(pluginOptions);
+  this.cellExternalCopyManager = new Slick.CellExternalCopyManager(
+    pluginOptions
+  );
 
   // Whether or not we register the CECM plugin depends on whether or not the
   // corresponding checkbox is checked. This should normally be true by
@@ -282,7 +308,7 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   // out checked. Either choice is valid -- this one just ensures that the JS
   // code for handling this checkbox is mostly localized to one place (here),
   // which should make life a little bit easier for us :)
-  if ($('#multiSelectCheckbox').prop('checked')) {
+  if ($("#multiSelectCheckbox").prop("checked")) {
     this.grid.registerPlugin(this.cellExternalCopyManager);
   }
 
@@ -300,18 +326,23 @@ PlateViewer.prototype.initialize = function (rows, cols) {
   this.grid.onContextMenu.subscribe(function(e) {
     e.preventDefault();
     var cell = that.grid.getCellFromEvent(e);
-    $('#wellContextMenu').data('row', cell.row).data('col', cell.cell).css('top', e.pageY).css('left', e.pageX).show();
-    $('body').one('click', function() {
-      $('#wellContextMenu').hide();
-    })
+    $("#wellContextMenu")
+      .data("row", cell.row)
+      .data("col", cell.cell)
+      .css("top", e.pageY)
+      .css("left", e.pageX)
+      .show();
+    $("body").one("click", function() {
+      $("#wellContextMenu").hide();
+    });
   });
 
   // Add the functionality to the context menu
-  $('#wellContextMenu').click(function (e) {
+  $("#wellContextMenu").click(function(e) {
     if (!$(e.target).is("li")) {
       return;
     }
-    if(!that.grid.getEditorLock().commitCurrentEdit()){
+    if (!that.grid.getEditorLock().commitCurrentEdit()) {
       return;
     }
     var row = $(this).data("row");
@@ -319,23 +350,28 @@ PlateViewer.prototype.initialize = function (rows, cols) {
     var func = $(e.target).attr("data");
 
     // Set up the modal to add a comment to the well
-    $('#addWellCommentBtn').off('click');
-    $('#addWellCommentBtn').on('click', function(){
-      that.commentWell(row, col, $('#wellTextArea').val());
+    $("#addWellCommentBtn").off("click");
+    $("#addWellCommentBtn").on("click", function() {
+      that.commentWell(row, col, $("#wellTextArea").val());
     });
 
-    $('#wellTextArea').val(that.wellComments[row][col]);
+    $("#wellTextArea").val(that.wellComments[row][col]);
 
     // Set the previous comment in the input
     // Show the modal
-    $('#addWellComment').modal('show');
+    $("#addWellComment").modal("show");
   });
 };
 
-PlateViewer.prototype.wellFormatter = function (row, col, value, columnDef, dataContext) {
-
-  var spanId = 'well-' + row + '-' + col;
-  var classes = '';
+PlateViewer.prototype.wellFormatter = function(
+  row,
+  col,
+  value,
+  columnDef,
+  dataContext
+) {
+  var spanId = "well-" + row + "-" + col;
+  var classes = "";
   // For some reason that goes beyond my knowledge, although this function
   // is part of the PlateViewer class, when accessing to "this" I do not retrieve
   // the plateViewer object. SlickGrid must be calling it in a weird way
@@ -343,14 +379,14 @@ PlateViewer.prototype.wellFormatter = function (row, col, value, columnDef, data
   if (vp.wellClasses[row][col].length > 0) {
     classes = ' class="' + vp.wellClasses[row][col][0];
     for (var i = 1; i < vp.wellClasses[row][col].length; i++) {
-      classes = classes + ' ' + vp.wellClasses[row][col][i];
+      classes = classes + " " + vp.wellClasses[row][col][i];
     }
     classes = classes + '"';
   }
   if (value === null) {
-    value = '';
+    value = "";
   }
-  return '<span id="' + spanId + '"' + classes + '>' + value + '</span>';
+  return '<span id="' + spanId + '"' + classes + ">" + value + "</span>";
 };
 
 /**
@@ -358,28 +394,27 @@ PlateViewer.prototype.wellFormatter = function (row, col, value, columnDef, data
  * Loads the plate layout in the current grid
  *
  **/
-PlateViewer.prototype.loadPlateLayout = function () {
+PlateViewer.prototype.loadPlateLayout = function() {
   var that = this;
 
-  $.get('/plate/' + this.plateId + '/layout', function (data) {
+  $.get("/plate/" + this.plateId + "/layout", function(data) {
     // Update the Grid data with the received information
     data = $.parseJSON(data);
     that.grid.invalidateAllRows();
     for (var i = 0; i < that.rows; i++) {
       for (var j = 0; j < that.cols; j++) {
-        that.data[i][j] = data[i][j]['sample'];
-        that.wellComments[i][j] = data[i][j]['notes'];
+        that.data[i][j] = data[i][j]["sample"];
+        that.wellComments[i][j] = data[i][j]["notes"];
         if (that.wellComments[i][j] !== null) {
-          that.wellClasses[i][j].push('well-commented');
+          that.wellClasses[i][j].push("well-commented");
         }
       }
     }
     that.grid.render();
     that.updateWellCommentsArea();
-  })
-    .fail(function (jqXHR, textStatus, errorThrown) {
-      bootstrapAlert(jqXHR.responseText, 'danger');
-    });
+  }).fail(function(jqXHR, textStatus, errorThrown) {
+    bootstrapAlert(jqXHR.responseText, "danger");
+  });
 };
 
 /**
@@ -390,7 +425,7 @@ PlateViewer.prototype.loadPlateLayout = function () {
  * back end (in sample_plating_process_handler_patch_request)
  * so do not change here without changing there.
  */
-PlateViewer.prototype.getActiveStudy = function () {
+PlateViewer.prototype.getActiveStudy = function() {
   studyID = get_active_studies().pop();
 
   if (studyID === undefined) {
@@ -408,63 +443,74 @@ PlateViewer.prototype.getActiveStudy = function () {
  * @param {string} content The new content of the well
  *
  **/
-PlateViewer.prototype.modifyWell = function (row, col, content) {
-  var that = this, studyID = this.getActiveStudy();
+PlateViewer.prototype.modifyWell = function(row, col, content) {
+  var that = this,
+    studyID = this.getActiveStudy();
 
-  $.ajax({url: '/process/sample_plating/' + this.processId,
-         type: 'PATCH',
-         data: {'op': 'replace', 'path': '/well/' + (row + 1) + '/' + (col + 1) + '/' + studyID + '/sample', 'value': content},
-         success: function (data) {
+  $.ajax({
+    url: "/process/sample_plating/" + this.processId,
+    type: "PATCH",
+    data: {
+      op: "replace",
+      path: "/well/" + (row + 1) + "/" + (col + 1) + "/" + studyID + "/sample",
+      value: content
+    },
+    success: function(data) {
+      that.data[row][that.grid.getColumns()[col].field] = data["sample_id"];
+      that.updateUnknownsAndDuplicates();
+      var classIdx = that.wellClasses[row][col].indexOf("well-prev-plated");
+      if (data["previous_plates"].length > 0) {
+        that.wellPreviousPlates[row][col] = data["previous_plates"];
+        addIfNotPresent(that.wellClasses[row][col], "well-prev-plated");
+      } else {
+        safeArrayDelete(that.wellClasses[row][col], "well-prev-plated");
+        that.wellPreviousPlates[row][col] = null;
+      }
 
-           that.data[row][that.grid.getColumns()[col].field] = data['sample_id'];
-           that.updateUnknownsAndDuplicates();
-           var classIdx = that.wellClasses[row][col].indexOf('well-prev-plated');
-           if (data['previous_plates'].length > 0) {
-             that.wellPreviousPlates[row][col] = data['previous_plates'];
-             addIfNotPresent(that.wellClasses[row][col], 'well-prev-plated');
-           } else {
-             safeArrayDelete(that.wellClasses[row][col], 'well-prev-plated');
-             that.wellPreviousPlates[row][col] = null;
-           }
-
-           // here and in the rest of the source we use updateRow instead of
-           // invalidateRow(s) and render so that we don't lose any active
-           // editors in the current grid
-           that.grid.updateRow(row);
-           that.updateWellCommentsArea();
-         },
-         error: function (jqXHR, textStatus, errorThrown) {
-           bootstrapAlert(jqXHR.responseText, 'danger');
-         }
+      // here and in the rest of the source we use updateRow instead of
+      // invalidateRow(s) and render so that we don't lose any active
+      // editors in the current grid
+      that.grid.updateRow(row);
+      that.updateWellCommentsArea();
+    },
+    error: function(jqXHR, textStatus, errorThrown) {
+      bootstrapAlert(jqXHR.responseText, "danger");
+    }
   });
 };
 
 /**
-**/
-PlateViewer.prototype.commentWell = function (row, col, comment) {
-  var that = this, studyID = this.getActiveStudy();
+ **/
+PlateViewer.prototype.commentWell = function(row, col, comment) {
+  var that = this,
+    studyID = this.getActiveStudy();
 
-  $.ajax({url: '/process/sample_plating/' + this.processId,
-         type: 'PATCH',
-         data: {'op': 'replace', 'path': '/well/' + (row + 1) + '/' + (col + 1) + '/' + studyID + '/notes', 'value': comment},
-         success: function (data) {
-           that.wellComments[row][col] = data['comment'];
-           var classIdx = that.wellClasses[row][col].indexOf('well-commented');
-           if (data['comment'] === null && classIdx > -1) {
-             that.wellClasses[row][col].splice(classIdx, 1);
-           } else if (data['comment'] !== null && classIdx === -1) {
-             that.wellClasses[row][col].push('well-commented')
-           }
+  $.ajax({
+    url: "/process/sample_plating/" + this.processId,
+    type: "PATCH",
+    data: {
+      op: "replace",
+      path: "/well/" + (row + 1) + "/" + (col + 1) + "/" + studyID + "/notes",
+      value: comment
+    },
+    success: function(data) {
+      that.wellComments[row][col] = data["comment"];
+      var classIdx = that.wellClasses[row][col].indexOf("well-commented");
+      if (data["comment"] === null && classIdx > -1) {
+        that.wellClasses[row][col].splice(classIdx, 1);
+      } else if (data["comment"] !== null && classIdx === -1) {
+        that.wellClasses[row][col].push("well-commented");
+      }
 
-           that.grid.updateRow(row);
+      that.grid.updateRow(row);
 
-           // Close the modal
-           $('#addWellComment').modal('hide');
-           that.updateWellCommentsArea();
-         },
-         error: function (jqXHR, textStatus, errorThrown) {
-           bootstrapAlert(jqXHR.responseText, 'danger');
-         }
+      // Close the modal
+      $("#addWellComment").modal("hide");
+      that.updateWellCommentsArea();
+    },
+    error: function(jqXHR, textStatus, errorThrown) {
+      bootstrapAlert(jqXHR.responseText, "danger");
+    }
   });
 };
 
@@ -479,73 +525,83 @@ PlateViewer.prototype.commentWell = function (row, col, comment) {
  * current grid
  *
  */
-PlateViewer.prototype.updateAllRows = function () {
-  for (var i = 0; i < this.rows; i ++ ) {
+PlateViewer.prototype.updateAllRows = function() {
+  for (var i = 0; i < this.rows; i++) {
     this.grid.updateRow(i);
   }
 };
 
-
-PlateViewer.prototype.updateUnknownsAndDuplicates = function () {
+PlateViewer.prototype.updateUnknownsAndDuplicates = function() {
   var that = this;
 
-  var successFunction = function (data) {
+  var successFunction = function(data) {
     var classIdx;
     // First remove all the instances of the unknown and duplicated css classes from  wells
     for (var i = 0; i < that.rows; i++) {
       for (var j = 0; j < that.cols; j++) {
-        safeArrayDelete(that.wellClasses[i][j], 'well-unknown');
-        safeArrayDelete(that.wellClasses[i][j], 'well-duplicated');
+        safeArrayDelete(that.wellClasses[i][j], "well-unknown");
+        safeArrayDelete(that.wellClasses[i][j], "well-duplicated");
       }
     }
     // Add the unknown class to all the current unknowns
-    $.each(data['unknowns'], function(idx, elem) {
+    $.each(data["unknowns"], function(idx, elem) {
       var row = elem[0] - 1;
       var col = elem[1] - 1;
-      that.wellClasses[row][col].push('well-unknown');
+      that.wellClasses[row][col].push("well-unknown");
     });
 
     // Add the duplicated class to all the current duplicates
-    $.each(data['duplicates'], function(idx, elem) {
+    $.each(data["duplicates"], function(idx, elem) {
       var row = elem[0] - 1;
       var col = elem[1] - 1;
-      that.wellClasses[row][col].push('well-duplicated');
+      that.wellClasses[row][col].push("well-duplicated");
     });
 
     that.updateAllRows();
   };
 
   $.ajax({
-      url: '/plate/' + this.plateId + '/',
-      dataType: "json",
-      // A value of 0 means there will be no timeout.
-      // from https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings
-      timeout: 0,
-      success: successFunction,
-      error: function (jqXHR, textStatus, errorThrown) {
-        bootstrapAlert(jqXHR.responseText, 'danger');
-      }
+    url: "/plate/" + this.plateId + "/",
+    dataType: "json",
+    // A value of 0 means there will be no timeout.
+    // from https://api.jquery.com/jquery.ajax/#jQuery-ajax-settings
+    timeout: 0,
+    success: successFunction,
+    error: function(jqXHR, textStatus, errorThrown) {
+      bootstrapAlert(jqXHR.responseText, "danger");
+    }
   });
 };
 
-PlateViewer.prototype.updateWellCommentsArea = function () {
+PlateViewer.prototype.updateWellCommentsArea = function() {
   var that = this;
   var msg;
-  $('#well-plate-comments').empty();
-  var rowId = 'A';
+  $("#well-plate-comments").empty();
+  var rowId = "A";
   var wellId;
   for (var i = 0; i < that.rows; i++) {
     for (var j = 0; j < that.cols; j++) {
       wellId = rowId + (j + 1);
-      if(that.wellComments[i][j] !== null) {
-        msg = 'Well ' + wellId + ' (' + that.data[i][j] + '): ' + that.wellComments[i][j];
-        $('<p>').append(msg).appendTo('#well-plate-comments');
-      } else if (that.wellPreviousPlates[i][j] !== null){
-        msg = 'Well ' + wellId + ' (' + that.data[i][j] + '): Plated in :';
+      if (that.wellComments[i][j] !== null) {
+        msg =
+          "Well " +
+          wellId +
+          " (" +
+          that.data[i][j] +
+          "): " +
+          that.wellComments[i][j];
+        $("<p>")
+          .append(msg)
+          .appendTo("#well-plate-comments");
+      } else if (that.wellPreviousPlates[i][j] !== null) {
+        msg = "Well " + wellId + " (" + that.data[i][j] + "): Plated in :";
         $.each(that.wellPreviousPlates[i][j], function(idx, elem) {
-          msg = msg + ' "' + elem['plate_name'] + '"'
+          msg = msg + ' "' + elem["plate_name"] + '"';
         });
-        $('<p>').addClass('well-prev-plated').append(msg).appendTo('#well-plate-comments');
+        $("<p>")
+          .addClass("well-prev-plated")
+          .append(msg)
+          .appendTo("#well-plate-comments");
       }
     }
     rowId = getNextRowId(rowId);
@@ -580,75 +636,84 @@ function SampleCellEditor(args) {
   this.blankNames = args.column.options.blankNamesRequest.responseJSON || [];
 
   // styling taken from SlickGrid's examples/examples.css file
-  this.init = function () {
+  this.init = function() {
     $input = $("<input type='text'>")
-        .appendTo(args.container)
-        .on("keydown.nav", function (e) {
-          if (e.keyCode === $.ui.keyCode.LEFT || e.keyCode === $.ui.keyCode.RIGHT) {
-            e.stopImmediatePropagation();
-          }
-        })
-        .css({'width': '100%',
-              'height':'100%',
-              'border':'0',
-              'margin':'0',
-              'background': 'transparent',
-              'outline': '0',
-              'padding': '0'});
+      .appendTo(args.container)
+      .on("keydown.nav", function(e) {
+        if (
+          e.keyCode === $.ui.keyCode.LEFT ||
+          e.keyCode === $.ui.keyCode.RIGHT
+        ) {
+          e.stopImmediatePropagation();
+        }
+      })
+      .css({
+        width: "100%",
+        height: "100%",
+        border: "0",
+        margin: "0",
+        background: "transparent",
+        outline: "0",
+        padding: "0"
+      });
 
-    $input.autocomplete({source: autocomplete_search_samples});
+    $input.autocomplete({ source: autocomplete_search_samples });
 
-    args.grid.setOptions({autoEdit: true});
+    args.grid.setOptions({ autoEdit: true });
   };
 
-  this.destroy = function () {
+  this.destroy = function() {
     $input.remove();
   };
 
-  this.focus = function () {
+  this.focus = function() {
     $input.focus();
   };
 
-  this.getValue = function () {
+  this.getValue = function() {
     return $input.val();
   };
 
-  this.setValue = function (val) {
+  this.setValue = function(val) {
     $input.val(val);
   };
 
-  this.loadValue = function (item) {
+  this.loadValue = function(item) {
     defaultValue = item[args.column.field] || "";
     $input.val(defaultValue);
     $input[0].defaultValue = defaultValue;
     $input.select();
   };
 
-  this.serializeValue = function () {
+  this.serializeValue = function() {
     return $input.val();
   };
 
-  this.applyValue = function (item, state) {
-    var activeStudies, studyPrefix = '';
+  this.applyValue = function(item, state) {
+    var activeStudies,
+      studyPrefix = "";
 
     // account for the callback when copying or pasting
     if (state === null) {
-      state = '';
+      state = "";
     }
-    
-    if (state.replace(/\s/g,'').length === 0) {
+
+    if (state.replace(/\s/g, "").length === 0) {
       // The user introduced an empty string. An empty string in a plate is a blank
-      state = 'blank';
+      state = "blank";
     }
 
     item[args.column.field] = state;
   };
 
-  this.isValueChanged = function () {
-    return (!($input.val() == "" && defaultValue == null)) && ($input.val() != defaultValue);
+  this.isValueChanged = function() {
+    return (
+      !($input.val() == "" && defaultValue == null) &&
+      $input.val() != defaultValue
+    );
   };
 
-  this.validate = function () {
+  this.validate = function() {
     if (args.column.validator) {
       var validationResults = args.column.validator($input.val());
       if (!validationResults.valid) {
@@ -678,17 +743,17 @@ function autocomplete_search_samples(request, response) {
   var studyIds = get_active_studies();
 
   // Perform all the requests to the server
-  var requests = [$.get('/sample/control?term=' + request.term)];
-  $.each(studyIds, function (index, value) {
-    requests.push($.get('/study/' + value + '/samples?term=' + request.term));
+  var requests = [$.get("/sample/control?term=" + request.term)];
+  $.each(studyIds, function(index, value) {
+    requests.push($.get("/study/" + value + "/samples?term=" + request.term));
   });
 
-  $.when.apply($, requests).then(function () {
+  $.when.apply($, requests).then(function() {
     // The nature of arguments change based on the number of requests performed
     // If only one request was performed, then arguments only contain the output
     // of that request. On the other hand, if there was more than one request,
     // then arguments is a list of results
-    var arg = (requests.length === 1) ? [arguments] : arguments;
+    var arg = requests.length === 1 ? [arguments] : arguments;
     var samples = [];
     $.each(arg, function(index, value) {
       samples = samples.concat($.parseJSON(value[0]));
@@ -696,7 +761,7 @@ function autocomplete_search_samples(request, response) {
     // Format the samples in the way that autocomplete needs
     var results = [];
     $.each(samples, function(index, value) {
-      results.push({'label': value, 'value': value});
+      results.push({ label: value, value: value });
     });
     response(results);
   });
@@ -707,23 +772,22 @@ function autocomplete_search_samples(request, response) {
  * @returns {Array} A list of study identifiers that are currently selected.
  */
 function get_active_studies() {
-  var $studies = $('.study-list-item.active');
+  var $studies = $(".study-list-item.active");
   var studyIds = [];
 
   if ($studies.length === 0) {
     // There are no studies chosen - search over all studies in the list:
-    $.each($('.study-list-item'), function (index, value) {
-      studyIds.push($(value).attr('pm-data-study-id'));
+    $.each($(".study-list-item"), function(index, value) {
+      studyIds.push($(value).attr("pm-data-study-id"));
     });
   } else {
-    $.each($studies, function (index, value) {
-      studyIds.push($(value).attr('pm-data-study-id'));
+    $.each($studies, function(index, value) {
+      studyIds.push($(value).attr("pm-data-study-id"));
     });
   }
 
   return studyIds;
 }
-
 
 /**
  * Small widget to add notes and save them to a URI
@@ -739,22 +803,24 @@ function NotesBox(container, uri, id, options) {
   var that = this;
   options = options || {};
 
-  this.title = options.title || 'Notes';
-  this.placeholder = options.placeholder || 'Enter your notes and click ' +
-                                            'the save button';
-  this.text = '';
+  this.title = options.title || "Notes";
+  this.placeholder =
+    options.placeholder || "Enter your notes and click " + "the save button";
+  this.text = "";
   this.uri = uri;
   this.id = id;
   this.$container = $(container);
 
-  this.$main = $('<div></div>').addClass('form-group').width('100%');
+  this.$main = $("<div></div>")
+    .addClass("form-group")
+    .width("100%");
   this.$container.append(this.$main);
 
-  this.$label = $('<label></label>').width('100%');
+  this.$label = $("<label></label>").width("100%");
   this.$textArea = $('<textarea class="form-control"></textarea>');
-  this.$textArea.css({width: '100%'});
+  this.$textArea.css({ width: "100%" });
   this.$saveButton = $('<button type="button">Save Notes</button>');
-  this.$saveButton.addClass('btn btn-primary');
+  this.$saveButton.addClass("btn btn-primary");
 
   this.$label.html(this.title);
   this.$label.append(this.$textArea);
@@ -762,18 +828,18 @@ function NotesBox(container, uri, id, options) {
   this.$main.append(this.$label);
   this.$main.append(this.$saveButton);
 
-  this.$textArea.on('input', function() {
-    that.$saveButton.removeClass('btn-primary btn-danger btn-success');
-    that.$saveButton.addClass('btn-primary');
-    that.$saveButton.html('Save Notes');
+  this.$textArea.on("input", function() {
+    that.$saveButton.removeClass("btn-primary btn-danger btn-success");
+    that.$saveButton.addClass("btn-primary");
+    that.$saveButton.html("Save Notes");
     that.text = that.$textArea.val();
   });
 
-  this.$textArea.attr('placeholder', this.placeholder);
+  this.$textArea.attr("placeholder", this.placeholder);
 
-  this.$saveButton.on('click', function() {
+  this.$saveButton.on("click", function() {
     that.save();
-    $(this).addClass('disabled');
+    $(this).addClass("disabled");
   });
 }
 
@@ -796,24 +862,28 @@ NotesBox.prototype.setText = function(text, save) {
 /**
  * Method to write the notes into the uri.
  */
-NotesBox.prototype.save = function () {
+NotesBox.prototype.save = function() {
   var that = this;
 
   $.ajax({
-    type: 'POST',
+    type: "POST",
     url: this.uri,
-    data: {process_id: this.id, notes: this.text},
+    data: { process_id: this.id, notes: this.text }
   })
-  .done(function() {
-      that.$saveButton.removeClass('disabled btn-primary btn-danger btn-success');
-      that.$saveButton.addClass('btn-success');
+    .done(function() {
+      that.$saveButton.removeClass(
+        "disabled btn-primary btn-danger btn-success"
+      );
+      that.$saveButton.addClass("btn-success");
 
-      that.$saveButton.html('Save Notes (successfully saved)');
+      that.$saveButton.html("Save Notes (successfully saved)");
     })
-  .fail(function() {
-      that.$saveButton.removeClass('disabled btn-primary btn-danger btn-success');
-      that.$saveButton.addClass('btn-danger');
+    .fail(function() {
+      that.$saveButton.removeClass(
+        "disabled btn-primary btn-danger btn-success"
+      );
+      that.$saveButton.addClass("btn-danger");
 
-      that.$saveButton.html('Save Notes (error, try again)');
+      that.$saveButton.html("Save Notes (error, try again)");
     });
 };

--- a/labcontrol/gui/static/js/reagentModal.js
+++ b/labcontrol/gui/static/js/reagentModal.js
@@ -1,11 +1,11 @@
 // This component is a modal to add new reagents to the system
 
-ReagentModalComponent = Vue.component('reagent-modal', {
+ReagentModalComponent = Vue.component("reagent-modal", {
   // reagent-type: The reagent type
   // id-prefix: Prefix to set up the id for all internal modal values
   // input-taget; The input element that the user is typing the reagent
   // checks-callback: Function to execute when the input-target changes
-  props: ['reagent-type', 'id-prefix', 'input-target', 'checks-callback'],
+  props: ["reagent-type", "id-prefix", "input-target", "checks-callback"],
   methods: {
     /**
      *
@@ -19,16 +19,21 @@ ReagentModalComponent = Vue.component('reagent-modal', {
      *
      **/
     autocompleteSearchReagent: function(request, response) {
-      $.get('/composition/reagent?reagent_type=' + this.reagentType + '&term=' + request.term, function (data) {
-        response($.parseJSON(data));
-      })
-        .fail(function (jqXHR, textStatus, errorThrown) {
-          bootstrapAlert(jqXHR.responseText, 'danger');
-          // The autocomplete documentation specifies that you should always
-          // call response, even when a failure happens, to make sure that the
-          // object is left in a safe state.
-          response([]);
-        });
+      $.get(
+        "/composition/reagent?reagent_type=" +
+          this.reagentType +
+          "&term=" +
+          request.term,
+        function(data) {
+          response($.parseJSON(data));
+        }
+      ).fail(function(jqXHR, textStatus, errorThrown) {
+        bootstrapAlert(jqXHR.responseText, "danger");
+        // The autocomplete documentation specifies that you should always
+        // call response, even when a failure happens, to make sure that the
+        // object is left in a safe state.
+        response([]);
+      });
     },
 
     /**
@@ -39,31 +44,38 @@ ReagentModalComponent = Vue.component('reagent-modal', {
      * already exists. If it doesn't exist, it shows the modal to create it.
      *
      **/
-    onChangeAutocomplete: function () {
+    onChangeAutocomplete: function() {
       // Check if the given reagent exists - if it doesn't exist, show the modal
       // to create it
       let that = this;
-      var value = $('#' + this.inputTarget).val();
-      if (value !== '') {
-        $.get('/composition/reagent?reagent_type=' + this.reagentType + '&term=' + value, function (data) {
-          results = $.parseJSON(data);
-          if ($.inArray(value, results) === -1) {
-            $('#' + that.idPrefix + '-modal').modal('show');
-            // Set the lotId value in the modal input
-            $('#' + that.idPrefix + '-lot-id-input').val($('#' + that.inputTarget).val());
-            // Set the focus on the lotId input
-            $('#' + that.idPrefix + '-lot-id-input');
-            // Perform the input checks
-            that.creationChecks();
-            // Reset the target input value
-            $('#' + that.inputTarget).val('');
-          } else {
-            that.checksCallback();
+      var value = $("#" + this.inputTarget).val();
+      if (value !== "") {
+        $.get(
+          "/composition/reagent?reagent_type=" +
+            this.reagentType +
+            "&term=" +
+            value,
+          function(data) {
+            results = $.parseJSON(data);
+            if ($.inArray(value, results) === -1) {
+              $("#" + that.idPrefix + "-modal").modal("show");
+              // Set the lotId value in the modal input
+              $("#" + that.idPrefix + "-lot-id-input").val(
+                $("#" + that.inputTarget).val()
+              );
+              // Set the focus on the lotId input
+              $("#" + that.idPrefix + "-lot-id-input");
+              // Perform the input checks
+              that.creationChecks();
+              // Reset the target input value
+              $("#" + that.inputTarget).val("");
+            } else {
+              that.checksCallback();
+            }
           }
-        })
-          .fail(function (jqXHR, textStatus, errorThrown) {
-            bootstrapAlert(jqXHR.responseText, 'danger');
-          });
+        ).fail(function(jqXHR, textStatus, errorThrown) {
+          bootstrapAlert(jqXHR.responseText, "danger");
+        });
       } else {
         that.checksCallback();
       }
@@ -79,9 +91,19 @@ ReagentModalComponent = Vue.component('reagent-modal', {
      **/
     inputCheckFormatter: function(inputDivName, isOk) {
       if (isOk) {
-        $('#' + inputDivName).removeClass('has-error').addClass('has-success').find('span').removeClass('glyphicon-remove').addClass('glyphicon-ok');
+        $("#" + inputDivName)
+          .removeClass("has-error")
+          .addClass("has-success")
+          .find("span")
+          .removeClass("glyphicon-remove")
+          .addClass("glyphicon-ok");
       } else {
-        $('#' + inputDivName).removeClass('has-success').addClass('has-error').find('span').removeClass('glyphicon-ok').addClass('glyphicon-remove');
+        $("#" + inputDivName)
+          .removeClass("has-success")
+          .addClass("has-error")
+          .find("span")
+          .removeClass("glyphicon-ok")
+          .addClass("glyphicon-remove");
       }
     },
 
@@ -93,19 +115,24 @@ ReagentModalComponent = Vue.component('reagent-modal', {
      * is > 0, then it enables the add button, otherwise it is left disabled.
      *
      **/
-    creationChecks: function(){
+    creationChecks: function() {
       let that = this;
-      var lotId = $('#' + this.idPrefix + '-lot-id-input').val();
+      var lotId = $("#" + this.idPrefix + "-lot-id-input").val();
 
-      $.get('/composition/reagent?reagent_type=' + this.reagentType + '&term=' + lotId, function (data) {
-        results = $.parseJSON(data);
-        var lotOk = ($.inArray(lotId, results) === -1);
-        that.inputCheckFormatter(that.idPrefix + '-lot-id-div', lotOk);
-        $('#' + that.idPrefix + '-btn').prop('disabled', !(lotOk));
-      })
-        .fail(function (jqXHR, textStatus, errorThrown) {
-          bootstrapAlert(jqXHR.responseText, 'danger');
-        });
+      $.get(
+        "/composition/reagent?reagent_type=" +
+          this.reagentType +
+          "&term=" +
+          lotId,
+        function(data) {
+          results = $.parseJSON(data);
+          var lotOk = $.inArray(lotId, results) === -1;
+          that.inputCheckFormatter(that.idPrefix + "-lot-id-div", lotOk);
+          $("#" + that.idPrefix + "-btn").prop("disabled", !lotOk);
+        }
+      ).fail(function(jqXHR, textStatus, errorThrown) {
+        bootstrapAlert(jqXHR.responseText, "danger");
+      });
     },
 
     /**
@@ -115,26 +142,29 @@ ReagentModalComponent = Vue.component('reagent-modal', {
      **/
     createReagent: function() {
       let that = this;
-      var lotId = $('#' + this.idPrefix + '-lot-id-input').val();
-      $.post('/composition/reagent', {'external_id': lotId, 'volume': 1, 'reagent_type': this.reagentType}, function (data) {
-        // The reagent has been created
-        // Set the value in the target input
-        $('#' + that.inputTarget).val(lotId);
-        // Close the modal
-        $('#' + that.idPrefix + '-modal').modal('hide');
-        // Execute the checks callback
-        that.checksCallback();
-      })
-        .fail(function (jqXHR, textStatus, errorThrown) {
-          // Show the error
-          bootstrapAlert(jqXHR.responseText, 'danger');
-          // Hide the modal
-          $('#' + that.idPrefix + '-modal').modal('hide');
-          // Reset the value
-          $('#' + that.inputTarget).val('');
+      var lotId = $("#" + this.idPrefix + "-lot-id-input").val();
+      $.post(
+        "/composition/reagent",
+        { external_id: lotId, volume: 1, reagent_type: this.reagentType },
+        function(data) {
+          // The reagent has been created
+          // Set the value in the target input
+          $("#" + that.inputTarget).val(lotId);
+          // Close the modal
+          $("#" + that.idPrefix + "-modal").modal("hide");
           // Execute the checks callback
           that.checksCallback();
-        });
+        }
+      ).fail(function(jqXHR, textStatus, errorThrown) {
+        // Show the error
+        bootstrapAlert(jqXHR.responseText, "danger");
+        // Hide the modal
+        $("#" + that.idPrefix + "-modal").modal("hide");
+        // Reset the value
+        $("#" + that.inputTarget).val("");
+        // Execute the checks callback
+        that.checksCallback();
+      });
     }
   },
 
@@ -152,18 +182,25 @@ ReagentModalComponent = Vue.component('reagent-modal', {
 
     // modal-header: contains the button to close the modal and the modal title
     var divModalHeader = createElement(
-      'div', // Element type
-      {'class': {'modal-header': true}}, // Element attributes
-      [ // Children
+      "div", // Element type
+      { class: { "modal-header": true } }, // Element attributes
+      [
+        // Children
         // Close button
         createElement(
-          'button',
-          {'class': {'close': true},
-           'attrs': {'type': 'button', 'data-dismiss': 'modal', 'aria-hidden': 'true'}},
-          ['x']
+          "button",
+          {
+            class: { close: true },
+            attrs: {
+              type: "button",
+              "data-dismiss": "modal",
+              "aria-hidden": "true"
+            }
+          },
+          ["x"]
         ),
         // Header
-        createElement('h3', 'Add new ' + this.reagentType),
+        createElement("h3", "Add new " + this.reagentType)
       ]
     );
 
@@ -173,55 +210,88 @@ ReagentModalComponent = Vue.component('reagent-modal', {
 
     // External lot id input div
     var divLotId = createElement(
-      'div',
-      {'class': {'form-group': true, 'has-error': true, 'has-feedback': true}, 'attrs': {'id': this.idPrefix + '-lot-id-div'}},
+      "div",
+      {
+        class: { "form-group": true, "has-error": true, "has-feedback": true },
+        attrs: { id: this.idPrefix + "-lot-id-div" }
+      },
       [
         // The label
-        createElement('label', {'attrs': {'for': this.idPrefix + '-lot-id-input'}}, 'Lot id:'),
+        createElement(
+          "label",
+          { attrs: { for: this.idPrefix + "-lot-id-input" } },
+          "Lot id:"
+        ),
         // The input
-        createElement('input', {'class': {'form-control': true},
-                                'attrs': {'type': 'text', 'id': this.idPrefix + '-lot-id-input'},
-                                'on': {'change': this.creationChecks}}),
+        createElement("input", {
+          class: { "form-control": true },
+          attrs: { type: "text", id: this.idPrefix + "-lot-id-input" },
+          on: { change: this.creationChecks }
+        }),
         // The span
-        createElement('span', {'class': {'glyphicon': true, 'glyphicon-remove': true, 'form-control-feedback': true}})
+        createElement("span", {
+          class: {
+            glyphicon: true,
+            "glyphicon-remove": true,
+            "form-control-feedback": true
+          }
+        })
       ]
     );
     // The modal-body div containing the 2 input divs
-    var divModalBody = createElement('div', {'class': {'modal-body': true}}, [divLotId]);
+    var divModalBody = createElement("div", { class: { "modal-body": true } }, [
+      divLotId
+    ]);
 
     // modal-footer: contains the create reagent button
     var divModalFooter = createElement(
-      'div',
-      {'class': {'modal-footer': true}},
+      "div",
+      { class: { "modal-footer": true } },
       [
         // button
         createElement(
-          'button',
-          {'class': {'btn': true, 'btn-default': true},
-           'attrs': {'disabled': true, 'id': this.idPrefix + '-btn'},
-           'on': {'click': this.createReagent}},
-          'Add')
+          "button",
+          {
+            class: { btn: true, "btn-default": true },
+            attrs: { disabled: true, id: this.idPrefix + "-btn" },
+            on: { click: this.createReagent }
+          },
+          "Add"
+        )
       ]
     );
 
     // The modal content div, containing the header, body and footer divs
-    var divModalContent = createElement('div', {'class': {'modal-content': true}}, [divModalHeader, divModalBody, divModalFooter]);
+    var divModalContent = createElement(
+      "div",
+      { class: { "modal-content": true } },
+      [divModalHeader, divModalBody, divModalFooter]
+    );
     // The modal dialog div, containing the modal content div
-    var divModalDialog = createElement('div', {'class': {'modal-dialog': true, 'modal-lg': true}}, [divModalContent]);
+    var divModalDialog = createElement(
+      "div",
+      { class: { "modal-dialog": true, "modal-lg": true } },
+      [divModalContent]
+    );
     // The modal div, containing the modal dialog div
     var divModal = createElement(
-      'div',
-      {'class': {'modal': true, 'fade': true},
-       'attrs': {'tabindex': -1, 'role': 'dialog', 'id': this.idPrefix + '-modal'}},
-      [divModalDialog]);
+      "div",
+      {
+        class: { modal: true, fade: true },
+        attrs: { tabindex: -1, role: "dialog", id: this.idPrefix + "-modal" }
+      },
+      [divModalDialog]
+    );
     return divModal;
   },
 
   // VUE function called once the component DOM has been generated
   mounted() {
     // Set up the autocomplete in the input target
-    $('#' + this.inputTarget).autocomplete({source: this.autocompleteSearchReagent});
+    $("#" + this.inputTarget).autocomplete({
+      source: this.autocompleteSearchReagent
+    });
     // Set the on change event callback
-    $('#' + this.inputTarget).on('change', this.onChangeAutocomplete);
+    $("#" + this.inputTarget).on("change", this.onChangeAutocomplete);
   }
 });

--- a/labcontrol/gui/templates/plate.html
+++ b/labcontrol/gui/templates/plate.html
@@ -97,6 +97,12 @@
 
     }
 
+    // Ensure that the plate-conf-select ALWAYS starts on "Choose plate
+    // configuration...", even if the back/forward browser buttons are used to
+    // get here after selecting something different. (See issue #562.)
+    // Solution from https://stackoverflow.com/a/10502152/10730311.
+    $('#plate-conf-select').prop('selectedIndex', 0);
+
     // Add the change callback to the plate configuration select
     $('#plate-conf-select').on('change', change_plate_configuration);
   });

--- a/labcontrol/gui/templates/plate_list.html
+++ b/labcontrol/gui/templates/plate_list.html
@@ -4,8 +4,6 @@
 
   var dtSelectedCounter = 0;
 
-  // NOTE: Can't contain a "nothing" key below, since that's the default value
-  // used in the plate-type-select
   var buttonsInfo = {
     'sample': {'buttons': [{'label': 'Extract plates', 'urlTarget': '/process/gdna_extraction'}],
                'description': 'Sample plates'},
@@ -88,10 +86,16 @@
        'order': [[1, "desc"]],
        'language': {'zeroRecords': 'No plates found - choose a plate type'}});
 
-    // Ensure that the plate-type-select ALWAYS starts on the "Choose plate
-    // type..." option, even if the user navigates back/forward to this page
-    // after selecting something different (resolves issue #562)
-    $('#plate-type-select').val('nothing');
+    /* Ensure that the plate-type-select ALWAYS starts on the "Choose plate
+     * type..." option, even if the user navigates back/forward to this page
+     * after selecting something different (resolves issue #562).
+     * (Using the selectedIndex property instead of using a value for the
+     * "Choose plate type..." option allows us to not set a value for that
+     * option -- if we did that we'd risk the value we choose conflicting with
+     * a possible future plate type.)
+     * Solution c/o https://stackoverflow.com/a/10502152/10730311.
+     */
+    $('#plate-type-select').prop('selectedIndex', 0);
 
     $('#plate-type-select').on('change', function() {
       var plateType = $(this).val();
@@ -167,7 +171,7 @@
 <div class='form-group'>
   <label class='control-label'><h4>Plate type:</h4></label>
   <select id='plate-type-select' class='form-control'>
-    <option value="nothing" selected disabled>Choose plate type...</option>
+    <option selected disabled>Choose plate type...</option>
   </select>
 </div>
 

--- a/labcontrol/gui/templates/plate_list.html
+++ b/labcontrol/gui/templates/plate_list.html
@@ -4,6 +4,8 @@
 
   var dtSelectedCounter = 0;
 
+  // NOTE: Can't contain a "nothing" key below, since that's the default value
+  // used in the plate-type-select
   var buttonsInfo = {
     'sample': {'buttons': [{'label': 'Extract plates', 'urlTarget': '/process/gdna_extraction'}],
                'description': 'Sample plates'},
@@ -86,6 +88,11 @@
        'order': [[1, "desc"]],
        'language': {'zeroRecords': 'No plates found - choose a plate type'}});
 
+    // Ensure that the plate-type-select ALWAYS starts on the "Choose plate
+    // type..." option, even if the user navigates back/forward to this page
+    // after selecting something different (resolves issue #562)
+    $('#plate-type-select').val('nothing');
+
     $('#plate-type-select').on('change', function() {
       var plateType = $(this).val();
 
@@ -160,7 +167,7 @@
 <div class='form-group'>
   <label class='control-label'><h4>Plate type:</h4></label>
   <select id='plate-type-select' class='form-control'>
-    <option selected disabled>Choose plate type...</option>
+    <option value="nothing" selected disabled>Choose plate type...</option>
   </select>
 </div>
 


### PR DESCRIPTION
We can swap out prettier / change configs / etc. really easily, if desired (all that is needed is updating the Makefile, which I added as part of this PR).

This PR *looks* hairy because it includes a lot of changes. However, the bulk of these are just automatic changes from running `make festyle` (and this is prefaced by doing a dry run with the `--debug-check` option, to check that stuff won't get broken by running `prettier --write`).

**For reviewers**, I'd suggest mainly just looking at the non-auto-formatter changes (which should be localized to the Travis YAML, the newly added Makefile, and plate.html + plate_list.html). This PR doesn't run prettier on the HTML yet (for reasons explained in the Makefile), so all of these changes aren't the result of prettier autoformatting everything.

**For running this autoformatter locally**, you can just run `npm install -g prettier` to install prettier on your system globally (this has been integrated into the Travis build process), then run `make festyle` from within the root directory of your LabControl repository to do autoformatting. You can also run `make festylecheck` to see if files would require autoformatting changes.